### PR TITLE
Update search functions to allow universal, and add examples in quickstart

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -32,18 +32,14 @@ class Client(object):
     def get_data_points(self, **selection):
         return lib.get_data_points(self.access_token, self.api_host, **selection)
 
-    def search(self, entity_type, search_terms):
-        return lib.search(self.access_token, self.api_host,
-                          entity_type, search_terms)
+    def search(self, search_terms, entity_type=None):
+        return lib.search(self.access_token, self.api_host, search_terms, entity_type)
 
-    def search_and_lookup(self, entity_type, search_terms):
-        return lib.search_and_lookup(self.access_token, self.api_host,
-                                     entity_type, search_terms)
+    def search_and_lookup(self, search_terms, entity_type=None):
+        return lib.search_and_lookup(self.access_token, self.api_host, search_terms, entity_type)
 
     def lookup_belongs(self, entity_type, entity_id):
-        return lib.lookup_belongs(self.access_token, self.api_host,
-                                  entity_type, entity_id)
+        return lib.lookup_belongs(self.access_token, self.api_host, entity_type, entity_id)
 
     def rank_series_by_source(self, series_list):
-        return lib.rank_series_by_source(self.access_token, self.api_host,
-                                         series_list)
+        return lib.rank_series_by_source(self.access_token, self.api_host, series_list)

--- a/api/client/samples/crop_models/crop_model.py
+++ b/api/client/samples/crop_models/crop_model.py
@@ -54,7 +54,7 @@ class CropModel(api.client.Client):
         """Returns the first result of entity_type (which is items, metrics or
         regions) that matches the given keywords.
         """
-        results = self.search(entity_type, keywords)
+        results = self.search(keywords, entity_type)
         for result in results:
             self._logger.debug("First result, out of {} {}: {}".format(
                 len(results), entity_type, result['id']))

--- a/api/client/samples/quick_start.py
+++ b/api/client/samples/quick_start.py
@@ -6,30 +6,77 @@ API_HOST = 'api.gro-intelligence.com'
 OUTPUT_FILENAME = 'gro_client_output.csv'
 ACCESS_TOKEN=os.environ['GROAPI_TOKEN']
 
-def main():
-    client = api.client.Client(API_HOST, ACCESS_TOKEN)
+client = api.client.Client(API_HOST, ACCESS_TOKEN)
 
-    selected_entities = { u'region_id': 1038, # Cape Verde
-                          u'item_id': 5187, # Management of donkey manure
-                          u'metric_id': 5590032 } # Total Emissions Quantity (mass)
-
+def output_data_points_to_csv(data_points):
     writer = unicodecsv.writer(open(OUTPUT_FILENAME, 'wb'))
+    for point in data_points:
+        writer.writerow([
+            point['start_date'],
+            point['end_date'],
+            point['value'],
+            # input_unit_id is metadata for the point which refers to the unit the source reported
+            # it in originally. The following line translates the Gro id number for that unit into a
+            # human-readable abbreviation like kg or km^2
+            client.lookup_unit_abbreviation(point['input_unit_id'])
+        ])
+    print('Your data has been written to ' + OUTPUT_FILENAME)
 
-    # Get what possible series there are for that combination of selections
-    for data_series in client.get_data_series(**selected_entities):
-        
-        # Add a time range restriction to your data request (Optional - otherwise get all points)
-        data_series['start_date'] = '2000-01-01'
-        data_series['end_date'] = '2012-12-31'
+def main():
 
-        for point in client.get_data_points(**data_series):
-            writer.writerow([
-                point['start_date'],
-                point['end_date'],
-                point['value'],
-                client.lookup_unit_abbreviation(point['input_unit_id'])
-            ])
+    # search_and_lookup returns many results in descending order of relevance, so in each case
+    # we will just take the first one
+    cape_verde_id, cape_verde_type = list(client.search('cape verde'))[0]
 
+    # you can also specify the type if you want. In this case, we know management of donkey manure
+    # should be an item. Note the output is now just an id rather than an id and a type
+    manure_id = list(client.search('management of donkey manure', 'items'))[0]
+
+    # you can also lookup the results and see the names of these ids before you decide to use them
+    # either by using the client.search() function and then the client.lookup() function OR by using
+    # the client.search_and_lookup() helper utility
+    for entity_id, entity_type in client.search('emissions quantity'):
+        # In this case, we actually want "Total Emissions Quantity (mass)" so let's look for that
+        # one in the results
+        entity_details = client.lookup(entity_type, entity_id)
+        if entity_details['name'] == 'Total Emissions Quantity (mass)':
+            emissions_id = entity_id
+            break
+
+    # A data series, as Gro defines it, consists of a metric, item, region, source, and frequency.
+    # There is also sometimes a 6th entity type, partnerRegion, which applies when multiple the
+    # series refers to an interaction between two regions (importer & exporter, for example)
+    # You may select any subset of these 6 parameters and find relevant data series. Here, we will
+    # select the three most important: metric, item, and region
+    selected_entities = { u'region_id': cape_verde_id,
+                          u'item_id': manure_id,
+                          u'metric_id': emissions_id  }
+
+    print('Your selections: ' + str(selected_entities))
+
+    # Get what possible series there are for that combination of selections - there may be multiple
+    # possibilities, from different sources, different frequencies, etc.
+    possible_data_series = list(client.get_data_series(**selected_entities))
+    print('Your possible data series: ' + str(possible_data_series))
+
+    # get_data_series doesn't rank the series since you very well might just want all of them, but
+    # for our example, let's  use a ranking function to try to pick just the "best" one ("best" is a
+    # combination of recency of data, how far back the data goes, and how many data points are
+    # available):
+    best_data_series = list(client.rank_series_by_source(possible_data_series))[0]
+    print('Your best data series: ' + str(possible_data_series))
+
+    # You can add a time range restriction to your data request (Optional - otherwise get all points)
+    best_data_series['start_date'] = '2000-01-01'
+    best_data_series['end_date'] = '2012-12-31'
+
+    # Get an array of data_points for your chosen data_series
+    data_points = list(client.get_data_points(**best_data_series))
+
+    # You can output this list of points to any format you'd like, and we provide a helper function
+    # for outputting to a pandas dataframe, but here is a simple example of how you might write it
+    # to a CSV file:
+    output_data_points_to_csv(data_points)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Breaking changes**:

1. Re-arranged the parameters that `search()` and `search_and_lookup()` take so that `entity_type` is last and can be optional.
2. Changed the output of the `search()` function to an array of ids to more closely resemble the universal search format.

Other changes:

1. Added `search()` & `lookup()` examples to the quickstart so it answers a few more common questions
2. Added lots of comments to the quickstart
3. Added a superfluous `rank_series_by_source()` example
4. Updated the way `start_date` and `end_date` are getting added to the queryParams of getData so they get filtered out of any other type of call
5. Updated `lookup()` to accept both singular and plural types (universal search results are singular, but entity info routes i.e. `/v2/metrics/1234` are plural)