### PR TITLE
Allow show_revisions as a get_data_points input

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -161,7 +161,7 @@ def get_data_points(access_token, api_host, **selection):
   url = '/'.join(['https:', '', api_host, 'v2/data'])
   headers = {'authorization': 'Bearer ' + access_token }
   params = get_params_from_selection(**selection)
-  for key in filter(lambda k: k in selection, ['start_date', 'end_date', 'includes_revisions']):
+  for key in filter(lambda k: k in selection, ['start_date', 'end_date', 'show_revisions']):
     params[snake_to_camel(key)] = selection.get(key)
   resp = get_data(url, headers, params)
   return resp.json()


### PR DESCRIPTION
An example of it in use:

```
    data_series = {
        u'region_id': 1215,
        u'frequency_id': 9,
        u'source_id': 32,
        u'partner_region_id': 0,
        u'item_id': 274,
        u'metric_id': 170037,
        u'show_revisions': True
    }
    
    for point in client.get_data_points(**data_series):
        print([
            point['start_date'],
            point['end_date'],
            point['available_date'],
            point['reporting_date'],
            point['value'],
            client.lookup_unit_abbreviation(point['input_unit_id'])
        ])
```

You can see by toggling it on/off that you get all 214 results instead of the latest 1 for each of the 3 years.