### PR TITLE
Add crop calendar helper functions and inject into get_data_points()

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -186,33 +186,36 @@ def format_crop_calendar_response(resp):
     for dataEntry in point['data']:
       # Some start/end dates can be undefined (ex: {regionId: 12314, itemId: 95} - Wheat in Alta,
       # Russia). Those are returned as empty strings, so here I am checking for that and replacing
-      # those cases with Nones.
-      points.append({
-        u'input_unit_scale': None,
-        u'region_id': point['regionId'],
-        u'end_date': (dataEntry['plantingEndDate'] if dataEntry['plantingEndDate'] != '' else None),
-        u'input_unit_id': None,
-        u'value': 'planting',
-        u'frequency_id': point['frequencyId'],
-        u'available_date': None,
-        u'item_id': point['itemId'],
-        u'reporting_date': None,
-        u'start_date': (dataEntry['plantingStartDate'] if dataEntry['plantingStartDate'] != '' else None),
-        u'metric_id': point['metricId']
-      })
-      points.append({
-        u'input_unit_scale': None,
-        u'region_id': point['regionId'],
-        u'end_date': (dataEntry['harvestingEndDate'] if dataEntry['harvestingEndDate'] != '' else None),
-        u'input_unit_id': None,
-        u'value': 'harvesting',
-        u'frequency_id': point['frequencyId'],
-        u'available_date': None,
-        u'item_id': point['itemId'],
-        u'reporting_date': None,
-        u'start_date': (dataEntry['harvestingStartDate'] if dataEntry['harvestingStartDate'] != '' else None),
-        u'metric_id': point['metricId']
-      })
+      # those cases with Nones. Also, in some cases both start AND end are undefined, in which
+      # case I am excluding the data point entirely.
+      if(dataEntry['plantingStartDate'] != '' or dataEntry['plantingEndDate'] != ''):
+        points.append({
+          u'input_unit_scale': None,
+          u'region_id': point['regionId'],
+          u'end_date': (dataEntry['plantingEndDate'] if dataEntry['plantingEndDate'] != '' else None),
+          u'input_unit_id': None,
+          u'value': 'planting',
+          u'frequency_id': point['frequencyId'],
+          u'available_date': None,
+          u'item_id': point['itemId'],
+          u'reporting_date': None,
+          u'start_date': (dataEntry['plantingStartDate'] if dataEntry['plantingStartDate'] != '' else None),
+          u'metric_id': point['metricId']
+        })
+      if(dataEntry['harvestingStartDate'] != '' or dataEntry['harvestingEndDate'] != ''):
+        points.append({
+          u'input_unit_scale': None,
+          u'region_id': point['regionId'],
+          u'end_date': (dataEntry['harvestingEndDate'] if dataEntry['harvestingEndDate'] != '' else None),
+          u'input_unit_id': None,
+          u'value': 'harvesting',
+          u'frequency_id': point['frequencyId'],
+          u'available_date': None,
+          u'item_id': point['itemId'],
+          u'reporting_date': None,
+          u'start_date': (dataEntry['harvestingStartDate'] if dataEntry['harvestingStartDate'] != '' else None),
+          u'metric_id': point['metricId']
+        })
   return points
 
 def get_crop_calendar_data_points(access_token, api_host, **selection):


### PR DESCRIPTION
First, primary change here is this bit:

```python
if(selection['metric_id'] == CROP_CALENDAR_METRIC_ID):
    return get_crop_calendar_data_points(access_token, api_host, **selection)
```

This is making it so that you can call the same `get_data_points()` function without needing to know whether it's a crop calendar series or not - no special interface the user needs to worry about. In order to do that, though, I added three more helper functions that are not exposed:

`get_crop_calendar_data_points`, which uses `get_crop_calendar_params` and `format_crop_calendar_response`. You can see the comments of those functions for some explanation, but /v2/cropcalendars/data usually returns data in a format like

```python
[{
  u'itemId': 274,
  u'regionId': 13076,
  u'sourceId': 5,
  u'metricId': 2260063,
  u'frequencyId': 20,
  u'data': [{
    u'harvestingStartDate': u'2000-08-31',
    u'plantingStartDate': u'2000-04-04',
    u'harvestingEndDate': u'2000-11-30',
    u'sageItem': u'Corn',
    u'plantingEndDate': u'2000-06-09',
    u'multiYear': False
  }]
}]
```

which is inconsistent with other data responses, so I reformatted it into something more familiar:

```python
[{
  u'region_id': 13076,
  u'end_date': u'2000-06-09',
  u'available_date': None,
  u'item_id': 274,
  u'input_unit_scale': None,
  u'metric_id': 2260063,
  u'frequency_id': 20,
  u'value': 'planting',
  u'input_unit_id': None,
  u'reporting_date': None,
  u'start_date': u'2000-04-04'
}, {
  u'region_id': 13076,
  u'end_date': u'2000-11-30',
  u'available_date': None,
  u'item_id': 274,
  u'input_unit_scale': None,
  u'metric_id': 2260063,
  u'frequency_id': 20,
  u'value': 'harvesting',
  u'input_unit_id': None,
  u'reporting_date': None,
  u'start_date': u'2000-08-31'
}]
```

The only thing slightly unfamiliar about that is the fact that value is a string instead of an integer, but I thought that's probably clearer than making up some integers and communicating via comments what each integer represents. Also note that 'growing' isn't an actual data point, but in the web app we interpret any time between 'planting' and 'harvesting' as 'growing' - an API user could make that same assumption if they so wish, but I didn't include it as an actual data point.

Tested with the following script:

```python
import os
import unicodecsv
import api.client.lib

from api.client.gro_client import get_df

API_HOST = 'api.gro-intelligence.com'
ACCESS_TOKEN=os.environ['GROAPI_TOKEN']

def main():
  client = api.client.Client(API_HOST, ACCESS_TOKEN)

  # Original test case
  selected_entities = { u'region_id': 13076, # Missouri
                        u'item_id': 274, # Corn
                        u'metric_id': 2260063 } # Crop Calendar Date Range (date)
  for data_series in client.get_data_series(**selected_entities):
    print('\ndata_series')
    print(data_series)
    for point in client.get_data_points(**data_series):
      print('point', str(point))
  print('\ndata_frame')
  print(get_df(client, **selected_entities))

  # Example of calendar entry that includes undefined dates
  selected_entities = { u'region_id': 12314, # Alta
                        u'item_id': 95, # Wheat
                        u'metric_id': 2260063 } # Crop Calendar Date Range (date)
  for data_series in client.get_data_series(**selected_entities):
    print('\ndata_series')
    print(data_series)
    for point in client.get_data_points(**data_series):
      print('point\n', str(point))
  print('\ndata_frame')
  print(get_df(client, **selected_entities))

if __name__ == "__main__":
  main()
```

which gives me the output

```python
data_series
{u'end_date': u'2016-06-09T00:00:00.000Z', u'region_id': 13076, u'region_name': u'Missouri', u'item_name': u'Corn', u'partner_region_name': u'World', u'frequency_id': 20, u'source_id': 5, u'partner_region_id': 0, u'item_id': 274, u'metric_name': u'Crop Calendar Date Range (date)', u'start_date': u'2016-04-04T00:00:00.000Z', u'metric_id': 2260063}
('point', "{u'region_id': 13076, u'end_date': u'2000-06-09', u'available_date': None, u'item_id': 274, u'input_unit_scale': None, u'metric_id': 2260063, u'frequency_id': 20, u'value': 'planting', u'input_unit_id': None, u'reporting_date': None, u'start_date': u'2000-04-04'}")
('point', "{u'region_id': 13076, u'end_date': u'2000-11-30', u'available_date': None, u'item_id': 274, u'input_unit_scale': None, u'metric_id': 2260063, u'frequency_id': 20, u'value': 'harvesting', u'input_unit_id': None, u'reporting_date': None, u'start_date': u'2000-08-31'}")

data_frame
  available_date    end_date  frequency_id input_unit_id input_unit_scale  item_id  metric_id  region_id reporting_date  start_date       value
0           None  2000-06-09            20          None             None      274    2260063      13076           None  2000-04-04    planting
1           None  2000-11-30            20          None             None      274    2260063      13076           None  2000-08-31  harvesting

data_series
{u'end_date': u'2016-05-20T00:00:00.000Z', u'region_id': 12314, u'region_name': u'Altay', u'item_name': u'Wheat', u'partner_region_name': u'World', u'frequency_id': 20, u'source_id': 5, u'partner_region_id': 0, u'item_id': 95, u'metric_name': u'Crop Calendar Date Range (date)', u'start_date': u'2016-05-09T00:00:00.000Z', u'metric_id': 2260063}
('point\n', "{u'region_id': 12314, u'end_date': u'2000-05-20', u'available_date': None, u'item_id': 95, u'input_unit_scale': None, u'metric_id': 2260063, u'frequency_id': 20, u'value': 'planting', u'input_unit_id': None, u'reporting_date': None, u'start_date': u'2000-05-09'}")
('point\n', "{u'region_id': 12314, u'end_date': None, u'available_date': None, u'item_id': 95, u'input_unit_scale': None, u'metric_id': 2260063, u'frequency_id': 20, u'value': 'harvesting', u'input_unit_id': None, u'reporting_date': None, u'start_date': None}")

data_frame
  available_date    end_date  frequency_id input_unit_id input_unit_scale  item_id  metric_id  region_id reporting_date  start_date       value
0           None  2000-05-20            20          None             None       95    2260063      12314           None  2000-05-09    planting
1           None        None            20          None             None       95    2260063      12314           None        None  harvesting
```