### PR TITLE
Add undefined API_HOST variable to sugar.py

### DIFF
--- a/api/client/samples/crop_models/sugar.py
+++ b/api/client/samples/crop_models/sugar.py
@@ -24,6 +24,8 @@ import api.client.lib
 import os
 from api.client.samples.crop_models.crop_model import CropModel
 
+API_HOST = 'api.gro-intelligence.com'
+
 def main():
     parser = argparse.ArgumentParser(description="Gro api client")
     parser.add_argument("--user_email")


### PR DESCRIPTION
Fixes
`Traceback (most recent call last):
  File "sugar.py", line 71, in <module>
    main()
  File "sugar.py", line 40, in main
    access_token = api.client.lib.get_access_token(API_HOST, args.user_email, args.user_password)
NameError: global name 'API_HOST' is not defined
`