### PR TITLE
Only call model.get_df() if data series are returned

### DIFF
--- a/api/client/samples/crop_models/sugar.py
+++ b/api/client/samples/crop_models/sugar.py
@@ -45,7 +45,8 @@ def main():
     model = CropModel('api.gro-intelligence.com', access_token)
     model.add_data_series(item="sugarcane", metric="production quantity", region="Brazil")
     model.add_data_series(item="sugarcane", metric="yield", region="Brazil")
-    for data_series in model.get_data_series_list():
+    series_results = model.get_data_series_list()
+    for data_series in series_results:
         filename = 'gro_{}_{}_{}.csv'.format(
             model.lookup('items', data_series['item_id']).get('name'),
             model.lookup('metrics', data_series['metric_id']).get('name'),
@@ -60,8 +61,9 @@ def main():
             count += 1
         print "Output {} rows to {}".format(count, filename)
 
-    data_frame = model.get_df()
-    print "Loaded data frame of shape {}, columns: {}".format(data_frame.shape, data_frame.columns)
+    if series_results:
+        data_frame = model.get_df()
+        print "Loaded data frame of shape {}, columns: {}".format(data_frame.shape, data_frame.columns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes
`Traceback (most recent call last):
  File "sugar.py", line 69, in <module>
    main()
  File "sugar.py", line 64, in main
    data_frame = model.get_df()
  File "/home/james/git/api-client/api/client/samples/crop_models/crop_model.py", line 18, in get_df
    for series in self._data_series_list)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/reshape/concat.py", line 212, in concat
    copy=copy)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/reshape/concat.py", line 245, in __init__
    raise ValueError('No objects to concatenate')
ValueError: No objects to concatenate`