### PR TITLE
Update gro_client to use environment variable token if one exists

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -88,7 +88,7 @@ def main():
     parser.add_argument("--region")
     parser.add_argument("--partner_region")
     parser.add_argument("--print_token", action='store_true')
-    parser.add_argument("--token")
+    parser.add_argument("--token", default=os.environ.get('GROAPI_TOKEN'))
     args = parser.parse_args()
 
     assert args.user_email or args.token or os.environ['GROAPI_TOKEN'], \
@@ -97,8 +97,6 @@ def main():
 
     if args.token:
         access_token = args.token
-    elif os.environ['GROAPI_TOKEN']:
-      access_token = os.environ['GROAPI_TOKEN']
     else:
         if not args.user_password:
             args.user_password = getpass.getpass()

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -91,8 +91,7 @@ def main():
     parser.add_argument("--token", default=os.environ.get('GROAPI_TOKEN'))
     args = parser.parse_args()
 
-    assert args.user_email or args.token or os.environ['GROAPI_TOKEN'], \
-        "Need --token, or --user_email"
+    assert args.user_email or args.token, "Need --token, or --user_email, or $GROAPI_TOKEN"
     access_token = None
 
     if args.token:

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -14,6 +14,7 @@ import unicodecsv
 from random import random
 import pandas
 import api.client.lib
+import os
 
 
 API_HOST = 'api.gro-intelligence.com'
@@ -90,11 +91,14 @@ def main():
     parser.add_argument("--token")
     args = parser.parse_args()
 
-    assert args.user_email or args.token, \
+    assert args.user_email or args.token or os.environ['GROAPI_TOKEN'], \
         "Need --token, or --user_email"
     access_token = None
+
     if args.token:
         access_token = args.token
+    elif os.environ['GROAPI_TOKEN']:
+      access_token = os.environ['GROAPI_TOKEN']
     else:
         if not args.user_password:
             args.user_password = getpass.getpass()


### PR DESCRIPTION
Use GROAPI_TOKEN environment variable if one exists, so you don't have to enter your token or password every time when using the gro CLI.

This will currently favor a command-line provided token over the environment-set token, so you can overwrite it if you want.

Tested:

Without this change:

```shell
$ gro --metric='Production Quantity mass' --item='Corn' --region='United States'

Traceback (most recent call last):
  File "/home/john/.pyenv/versions/2.7.15/bin/gro", line 11, in <module>
    load_entry_point('gro==1.15.1', 'console_scripts', 'gro')()
  File "/home/john/dotfiles/configs/python/.pyenv/versions/2.7.15/lib/python2.7/site-packages/api/client/gro_client.py", line 94, in main
    "Need --token, or --user_email"
AssertionError: Need --token, or --user_email
```

```sh
pip uninstall gro
pip install git+https://github.com/gro-intelligence/api-client.git@gro-client-env-token
```

With this change:

```
$ pip install git+https://github.com/gro-intelligence/api-client.git@gro-client-env-token

$ gro --metric='Production Quantity mass' --item='Corn' --region='United States'
Picking first result out of 264 items: 274
Picking first result out of 500 metrics: 860032
Picking first result out of 500 regions: 1215
Data series example:
Using data series: {u'end_date': u'2019-08-31T00:00:00.000Z', u'source_name': u'USDA FEEDGRAINS', u'region_id': 1215, u'region_name': u'United States', u'item_name': u'Corn', u'partner_region_name': u'World', u'frequency_id': 9, u'source_id': 24, u'partner_region_id': 0, u'item_id': 274, u'metric_name': u'Production Quantity (mass)', u'start_date': u'1975-09-01T00:00:00.000Z', u'metric_id': 860032}
Outputing to file: gro_client_output.csv

$ gro --print_token
mysupersecuretokenthisisaplaceholdernottherealthing
```