### PR TITLE
Increment package version number to 1.19.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as requirements_file:
 
 setuptools.setup(
     name = "gro",
-    version = "1.16.8",
+    version = "1.19.1",
     description = "Python client library for accessing Gro Intelligence's agricultural data platform",
     long_description = long_description,
     long_description_content_type = "text/markdown",


### PR DESCRIPTION
For anyone affected by https://github.com/gro-intelligence/api-client/pull/39 incrementing the version number should allow for a pip upgrade to receive the latest version