### PR TITLE
 Add automatic redirecting in the case of migrations

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 CROP_CALENDAR_METRIC_ID = 2260063
 
+
 def get_default_logger():
   logger = logging.getLogger(__name__)
   logger.setLevel(cfg.DEFAULT_LOG_LEVEL)
@@ -16,6 +17,7 @@ def get_default_logger():
     stderr_handler = logging.StreamHandler()
     logger.addHandler(stderr_handler)
   return logger
+
 
 def get_access_token(api_host, user_email, user_password, logger=None):
   retry_count = 0
@@ -32,36 +34,36 @@ def get_access_token(api_host, user_email, user_password, logger=None):
     retry_count += 1
   raise Exception("Giving up on get_access_token after {0} tries.".format(retry_count))
 
+
 def redirect(params, migration):
-  """
-  Update query parameters to follow a redirection response from the API before
-  trying again.
+    """Update query parameters to follow a redirection response from the API.
 
-  >>> redirect( {'metricId': 14, 'sourceId': 2, 'itemId': 145},
-  ...           {'old_metric_id': 14, 'new_metric_id': 15,
-  ...            'old_item_id': -1, 'new_item_id': -1, 'source_id': 2})
-  {'sourceId': 2, 'itemId': 145, 'metricId': 15}
+    >>> redirect( {'metricId': 14, 'sourceId': 2, 'itemId': 145},
+    ...           {'old_metric_id': 14, 'new_metric_id': 15, 'source_id': 2})
+    {'sourceId': 2, 'itemId': 145, 'metricId': 15}
 
-  Parameters
-  ----------
-  params : dict
-    The original parameters provided to the API request
-  migration : dict
-    The body of the 301 response indicating which of the inputs have been
-    migrated and what values they have been migrated to
+    Parameters
+    ----------
+    params : dict
+        The original parameters provided to the API request
+    migration : dict
+        The body of the 301 response indicating which of the inputs have been
+        migrated and what values they have been migrated to
 
-  Returns
-  -------
-  params : dict
-    The mutated params object with values replaced according to the redirection
-    instructions provided by the API
-  """
+    Returns
+    -------
+    params : dict
+        The mutated params object with values replaced according to the
+        redirection instructions provided by the API
 
-  for key in migration:
-    split_key = key.split('_')
-    if split_key[0] == 'new' and migration[key] > -1:
-      params[snake_to_camel('_'.join([split_key[1], 'id']))] = migration[key]
-  return params
+    """
+    for migration_key in migration:
+        split_mig_key = migration_key.split('_')
+        if split_mig_key[0] == 'new':
+            param_key = snake_to_camel('_'.join([split_mig_key[1], 'id']))
+            params[param_key] = migration[migration_key]
+    return params
+
 
 def get_data(url, headers, params=None, logger=None):
   """General 'make api request' function. Assigns headers and builds in retries and logging."""
@@ -92,6 +94,7 @@ def get_data(url, headers, params=None, logger=None):
       params = redirect(params, data.json()['data'][0])
   raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(url, retry_count, data.text))
 
+
 def get_available(access_token, api_host, entity_type):
   """Given an entity_type, which is one of 'items', 'metrics',
     'regions', returns a JSON dict with the list of available entities
@@ -101,6 +104,7 @@ def get_available(access_token, api_host, entity_type):
   headers = {'authorization': 'Bearer ' + access_token}
   resp = get_data(url, headers)
   return resp.json()['data']
+
 
 def list_available(access_token, api_host, selected_entities):
   """List available entities given some selected entities. Given a dict
@@ -119,6 +123,7 @@ def list_available(access_token, api_host, selected_entities):
   except KeyError as e:
     raise Exception(resp.text)
 
+
 def lookup(access_token, api_host, entity_type, entity_id):
   """Given an entity_type, which is one of 'items', 'metrics',
   'regions', 'units', or 'sources', returns a JSON dict with the
@@ -132,10 +137,12 @@ def lookup(access_token, api_host, entity_type, entity_id):
   except KeyError as e:
     raise Exception(resp.text)
 
+
 def snake_to_camel(term):
   """Converts hello_world to helloWorld."""
   camel = term.split('_')
   return ''.join(camel[:1] + list([x[0].upper()+x[1:] for x in camel[1:]]))
+
 
 def get_params_from_selection(**selection):
   """Construct http request params from dict of entity selections. For use with get_data_series()
@@ -146,6 +153,7 @@ def get_params_from_selection(**selection):
     if key in ('region_id', 'partner_region_id', 'item_id', 'metric_id', 'source_id', 'frequency_id'):
       params[snake_to_camel(key)] = value
   return params
+
 
 def get_crop_calendar_params(**selection):
   """Construct http request params from dict of entity selections. Only region and item are required
@@ -158,6 +166,7 @@ def get_crop_calendar_params(**selection):
       params[snake_to_camel(key)] = value
   return params
 
+
 def get_data_call_params(**selection):
   """Construct http request params from dict of entity selections. For use with get_data_points().
   """
@@ -166,6 +175,7 @@ def get_data_call_params(**selection):
     if key in ('source_id', 'frequency_id', 'start_date', 'end_date', 'show_revisions'):
       params[snake_to_camel(key)] = value
   return params
+
 
 def get_data_series(access_token, api_host, **selection):
   """Get data series records for the given selection of entities.  which
@@ -181,6 +191,7 @@ def get_data_series(access_token, api_host, **selection):
     return resp.json()['data']
   except KeyError as e:
     raise Exception(resp.text)
+
 
 def rank_series_by_source(access_token, api_host, series_list):
   """Given a list of series, return them in source-ranked order: such
@@ -206,6 +217,7 @@ def rank_series_by_source(access_token, api_host, series_list):
       series_with_source = dict(series)
       series_with_source['source_id'] = source_id
       yield series_with_source
+
 
 def format_crop_calendar_response(resp):
   """Makes the v2/cropcalendar/data output a similar format to the normal /v2/data output. Splits
@@ -250,6 +262,7 @@ def format_crop_calendar_response(resp):
         })
   return points
 
+
 def get_crop_calendar_data_points(access_token, api_host, **selection):
   """Helper function for getting crop calendar data. Has different input/output from the regular
   /v2/data call, so this normalizes the interface and output format to make compatible
@@ -260,6 +273,7 @@ def get_crop_calendar_data_points(access_token, api_host, **selection):
   params = get_crop_calendar_params(**selection)
   resp = get_data(url, headers, params)
   return format_crop_calendar_response(resp.json())
+
 
 def get_data_points(access_token, api_host, **selection):
   """Get all the data points for a given selection, which is some or all
@@ -275,6 +289,7 @@ def get_data_points(access_token, api_host, **selection):
   resp = get_data(url, headers, params)
   return resp.json()
 
+
 def universal_search(access_token, api_host, search_terms):
   """Search across all entity types for the given terms.  Returns an a
   list of [id, entity_type] pairs, e.g.: [[5604, u'item'], [10204,
@@ -286,6 +301,7 @@ def universal_search(access_token, api_host, search_terms):
   resp = get_data(url, headers, {'q': search_terms})
   return resp.json()
 
+
 def search(access_token, api_host, entity_type, search_terms):
   """Given an entity_type, which is one of 'items', 'metrics',
   'regions', performs a search for the given terms. Returns a list of
@@ -296,6 +312,7 @@ def search(access_token, api_host, entity_type, search_terms):
   headers = {'authorization': 'Bearer ' + access_token }
   resp = get_data(url, headers, {'q': search_terms})
   return resp.json()
+
 
 def search_and_lookup(access_token, api_host, entity_type, search_terms):
   """Does a search for the given search terms, and for each result
@@ -310,6 +327,7 @@ def search_and_lookup(access_token, api_host, entity_type, search_terms):
   for result in search_results:
     yield lookup(access_token, api_host, entity_type, result['id'])
 
+
 def lookup_belongs(access_token, api_host, entity_type, entity_id):
   """Given an entity_type, which is one of 'items', 'metrics',
   'regions', and id, generates a list of JSON dicts of entities it
@@ -322,6 +340,7 @@ def lookup_belongs(access_token, api_host, entity_type, entity_id):
   for parent_entity_id in resp.json().get('data').get(str(entity_id), []):
     yield lookup(access_token, api_host, entity_type, parent_entity_id)
 
+
 def get_geo_centre(access_token, api_host, region_id):
   """Given a region ID, returns the geographic centre in degrees lat/lon."""
   url = '/'.join(['https:', '', api_host, 'v2/geocentres?regionIds=' + str(region_id)])
@@ -329,9 +348,10 @@ def get_geo_centre(access_token, api_host, region_id):
   resp = get_data(url, headers)
   return resp.json()["data"]
 
+
 def get_descendant_regions(access_token, api_host, region_id, descendant_level):
   """Given any region by id, recursively gets all the descendant regions
-  that are of the specified level. 
+  that are of the specified level.
 
   This takes advantage of the assumption that region graph is
   acyclic. This will only traverse ordered region levels (strictly

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -71,8 +71,7 @@ def get_data(url, headers, params=None, logger=None):
     logger = get_default_logger()
   logger.debug(url)
   logger.debug(params)
-  data = None
-  while retry_count < cfg.MAX_RETRIES and (data is None or data.status_code < 400):
+  while retry_count < cfg.MAX_RETRIES:
     start_time = time.time()
     data = requests.get(url, params=params, headers=headers, timeout=None)
     elapsed_time = time.time() - start_time


### PR DESCRIPTION
# Description

This PR adds automatic parameter adjustment when a 301 Redirect response is returned. Following the redirect causes a log error output indicating the migration, and it invokes a new request from the client with the updated parameters. Note it does take up one of the default 4 allowed retries - this is by design to hedge against possible circular redirects or long redirect chains.

# Testing

I added a test migration of item id 2142 to 3575, for source 28, on dev and ran the following script to test it:

```python
client = GroClient(API_HOST, ACCESS_TOKEN)
client.add_single_data_series({'metric_id':1090064, 'item_id':2142, 'region_id':0, 'source_id':28, 'frequency_id':9})
print('dataframe:', client.get_df().head())
```

Output:

```sh
$ python mig.py
Added {'item_id': 2142, 'source_id': 28, 'metric_id': 1090064, 'frequency_id': 9, 'region_id': 0}
{"message":"Requested entity has been migrated","data":[{"old_metric_id":-1,"new_metric_id":-1,"old_item_id":2142,"new_item_id":3575,"old_region_id":-1,"new_region_id":-1,"old_frequency_id":-1,"new_frequency_id":-1,"source_id":28,"timestamp":null}],"meta":{"version":"development","copyright":"Copyright (c) Gro Intelligence","timestamp":"Thu, 14 Mar 2019 21:32:21 GMT"}}
('dataframe:',                    end_date  frequency_id  input_unit_id  input_unit_scale  item_id  metric_id  region_id                start_date  unit_id        value
0  1990-12-31T00:00:00.000Z             9            294                 1     3575    1090064       1002  1990-01-01T00:00:00.000Z      294  2608.926433
1  1991-12-31T00:00:00.000Z             9            294                 1     3575    1090064       1002  1991-01-01T00:00:00.000Z      294  1909.591657
2  1992-12-31T00:00:00.000Z             9            294                 1     3575    1090064       1002  1992-01-01T00:00:00.000Z      294  1823.522005
3  1993-12-31T00:00:00.000Z             9            294                 1     3575    1090064       1002  1993-01-01T00:00:00.000Z      294  2058.654526
4  1994-12-31T00:00:00.000Z             9            294                 1     3575    1090064       1002  1994-01-01T00:00:00.000Z      294  2290.990927)
```

It followed the redirect and gave me the values for the migrated-to item instead of the item I requested.

Try the doctest:

```sh
$ python lib.py -v
Trying:
    redirect( {'metricId': 14, 'sourceId': 2, 'itemId': 145},
              {'old_metric_id': 14, 'new_metric_id': 15,
               'old_item_id': -1, 'new_item_id': -1, 'source_id': 2})
Expecting:
    {'sourceId': 2, 'itemId': 145, 'metricId': 15}
ok
22 items had no tests:
    __main__
    __main__.format_crop_calendar_response
    __main__.get_access_token
    __main__.get_available
    __main__.get_crop_calendar_data_points
    __main__.get_crop_calendar_params
    __main__.get_data
    __main__.get_data_call_params
    __main__.get_data_points
    __main__.get_data_series
    __main__.get_default_logger
    __main__.get_descendant_regions
    __main__.get_geo_centre
    __main__.get_params_from_selection
    __main__.list_available
    __main__.lookup
    __main__.lookup_belongs
    __main__.rank_series_by_source
    __main__.search
    __main__.search_and_lookup
    __main__.snake_to_camel
    __main__.universal_search
1 items passed all tests:
   1 tests in __main__.redirect
1 tests in 23 items.
1 passed and 0 failed.
Test passed.
```

Tested in both Python 2.7.15 and Python 3.7.0.