### PR TITLE
Add r usage example

### DIFF
--- a/r-client/.gitignore
+++ b/r-client/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/r-client/README.md
+++ b/r-client/README.md
@@ -6,22 +6,22 @@ What this Vagrantfile does is it creates an Ubunutu 16.04 virtual machine, insta
 
 This is implemented as a Vagrantfile to demonstrate exactly what dependencies are required in this specific test environment. This example is in no way saying you must or should use Vagrant if intending to use the Gro API in R yourself. It is also important to note that because R is not an officially supported language for using the Gro API, it may take extra configuration on the user's part, and not all features are tested.
 
-##Pre-requisites for running this example
+## Pre-requisites for running this example
 
 * vagrant
 * virtualbox
 
-##Preparation
+## Preparation
 
 In [src/testscript.R](src/testscript.R) replace the token string with your own token. See the README in the main repo here https://github.com/gro-intelligence/api-client for details on how to retrieve a token.
 
-##Run
+## Run
 
 ```sh
 $ vagrant up
 ```
 
-##To use this VM for testing your own R scripts
+## To use this VM for testing your own R scripts
 
 Modify [src/testscript.R](src/testscript.R) or create a copy of it, and replace the add_single_data_series and get_df lines with your own logic. Then,
 
@@ -33,13 +33,13 @@ $ Rscript /vagrant/<your-script>
 
 to run your own version of the script. Note it will create a new virtual environment and reinstall the Gro API client each time, so it does take a little while to run.
 
-##Destroy
+## Destroy
 
 ```sh
 $ vagrant destroy default -f
 ```
 
-##Documentation
+## Documentation
 
 * https://github.com/gro-intelligence/api-client/wiki
 * https://github.com/rstudio/reticulate

--- a/r-client/README.md
+++ b/r-client/README.md
@@ -1,19 +1,48 @@
 # Gro API Client R Usage Example
 
-This is a proof of concept use of the Gro API Python client https://github.com/gro-intelligence/api-client, imported and used in R via the `reticulate` R library. No special formatting or configuration needs to be done to the API client itself as plain Python functions interop with R inputs and outputs.
+This is a proof of concept use of the Gro API Python client (<https://github.com/gro-intelligence/api-client>), imported and used in R via the `reticulate` R library (<https://github.com/rstudio/reticulate>). No special formatting or configuration needs to be done to the API client itself as plain Python functions interop with R inputs and outputs.
 
-What this Vagrantfile does is it creates an Ubunutu 16.04 virtual machine, installs Python and R dependencies, and runs an R script emulating the quickstart example from https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/quick_start.py outputing an R dataframe at the end.
+## Using the API Client in R
 
-This is implemented as a Vagrantfile to demonstrate exactly what dependencies are required in this specific test environment. This example is in no way saying you must or should use Vagrant if intending to use the Gro API in R yourself. It is also important to note that because R is not an officially supported language for using the Gro API, it may take extra configuration on the user's part, and not all features are tested.
+### Pre-requisites
 
-## Pre-requisites for running this example
+* Python
+* pip
+* virtualenv
+* R
+
+### Importing the client
+
+```r
+# Reticulate allows python code to be used within R. Install and import
+install.packages("reticulate",repos = "http://cran.us.r-project.org")
+library(reticulate)
+# Install and import the Gro API client
+py_install("git+https://github.com/gro-intelligence/api-client.git")
+gro_client <- import("api.client.gro_client")
+# Create and authenticate a client object
+groclient = gro_client$GroClient("api.gro-intelligence.com","put-your-api-token-here")
+# -- Use the client below this line --
+```
+
+Replace the token string with your own token. See the [project README](/README.md#getting-a-token) for details on how to retrieve a token.
+
+## Running the example Vagrantfile
+
+This Vagrantfile creates an Ubunutu 16.04 virtual machine, installs Python and R dependencies, and runs an R script emulating the quickstart example from [quick_start.py](/api/client/samples/quick_start.py) outputing an R dataframe at the end.
+
+This is implemented as a Vagrantfile to demonstrate a known working configuration. This example is in no way saying you must or should use Vagrant if intending to use the Gro API in R yourself.
+
+It is important to note that because R is not an officially supported language for using the Gro API, integrating into your own environment may take extra configuration on the user's part, and not all features are tested.
+
+### Pre-requisites for Vagrant
 
 * vagrant
 * virtualbox
 
-## Preparation
+### Preparation
 
-In [src/testscript.R](src/testscript.R) replace the token string with your own token. See the README in the main repo here https://github.com/gro-intelligence/api-client for details on how to retrieve a token.
+In [src/testscript.R](src/testscript.R) replace the token string with your own token. See the [project README](/README.md#getting-a-token) for details on how to retrieve a token.
 
 ## Run
 
@@ -21,7 +50,7 @@ In [src/testscript.R](src/testscript.R) replace the token string with your own t
 $ vagrant up
 ```
 
-## To use this VM for testing your own R scripts
+### To use this VM for testing your own R scripts
 
 Modify [src/testscript.R](src/testscript.R) or create a copy of it, and replace the add_single_data_series and get_df lines with your own logic. Then,
 
@@ -33,7 +62,7 @@ $ Rscript /vagrant/<your-script>
 
 to run your own version of the script. Note it will create a new virtual environment and reinstall the Gro API client each time, so it does take a little while to run.
 
-## Destroy
+### Destroy
 
 ```sh
 $ vagrant destroy default -f

--- a/r-client/README.md
+++ b/r-client/README.md
@@ -1,0 +1,46 @@
+# Gro API Client R Usage Example
+
+This is a proof of concept use of the Gro API Python client https://github.com/gro-intelligence/api-client, imported and used in R via the `reticulate` R library. No special formatting or configuration needs to be done to the API client itself as plain Python functions interop with R inputs and outputs.
+
+What this Vagrantfile does is it creates an Ubunutu 16.04 virtual machine, installs Python and R dependencies, and runs an R script emulating the quickstart example from https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/quick_start.py outputing an R dataframe at the end.
+
+This is implemented as a Vagrantfile to demonstrate exactly what dependencies are required in this specific test environment. This example is in no way saying you must or should use Vagrant if intending to use the Gro API in R yourself. It is also important to note that because R is not an officially supported language for using the Gro API, it may take extra configuration on the user's part, and not all features are tested.
+
+##Pre-requisites for running this example
+
+* vagrant
+* virtualbox
+
+##Preparation
+
+In [src/testscript.R](src/testscript.R) replace the token string with your own token. See the README in the main repo here https://github.com/gro-intelligence/api-client for details on how to retrieve a token.
+
+##Run
+
+```sh
+$ vagrant up
+```
+
+##To use this VM for testing your own R scripts
+
+Modify [src/testscript.R](src/testscript.R) or create a copy of it, and replace the add_single_data_series and get_df lines with your own logic. Then,
+
+```sh
+$ vagrant ssh
+  password: vagrant
+$ Rscript /vagrant/<your-script>
+```
+
+to run your own version of the script. Note it will create a new virtual environment and reinstall the Gro API client each time, so it does take a little while to run.
+
+##Destroy
+
+```sh
+$ vagrant destroy default -f
+```
+
+##Documentation
+
+* https://github.com/gro-intelligence/api-client/wiki
+* https://github.com/rstudio/reticulate
+* https://rstudio.github.io/reticulate/articles/calling_python.html

--- a/r-client/Vagrantfile
+++ b/r-client/Vagrantfile
@@ -1,0 +1,8 @@
+Vagrant.configure("2") do |config|
+  # 18.04 apt version of python is 2.7.15rc1 instead of 2.7.15
+  # reticulate does not recognize that python version and fails
+  # 16.04 uses 2.7.12 by default, so use that instead.
+  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.synced_folder "./src", "/vagrant", owner: "vagrant"
+  config.vm.provision "shell", path: "./provision.sh"
+end

--- a/r-client/provision.sh
+++ b/r-client/provision.sh
@@ -1,0 +1,28 @@
+set -e # exit on any error
+
+echo "Update apt"
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+
+echo "Install pip"
+sudo apt-get install -y python-pip
+
+echo "Update pip"
+sudo -H pip install --upgrade pip
+
+echo "Install virtualenv"
+pip install virtualenv
+
+echo "Install R and Rscript"
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  r-base \
+  r-cran-littler
+
+echo "Grant /usr/local/lib/R/site-library ownership to vagrant user"
+sudo chown vagrant:vagrant -R /usr/local/lib/R/site-library
+
+# Fix Vagrant on Windows bug with symlinks
+# https://github.com/pypa/pipenv/issues/2084
+export VIRTUALENV_ALWAYS_COPY=1
+
+echo "Run test script"
+Rscript /vagrant/testscript.R

--- a/r-client/src/testscript.R
+++ b/r-client/src/testscript.R
@@ -6,5 +6,5 @@ gro_client <- import("api.client.gro_client")
 
 groclient = gro_client$GroClient("api.gro-intelligence.com","put-your-api-token-here")
 
-groclient$add_single_data_series(dict(mmetric_id=570001L, item_id=95L, region_id=1210L, source_id=2L, frequency_id=9L))
+groclient$add_single_data_series(dict(metric_id=570001L, item_id=95L, region_id=1210L, source_id=2L, frequency_id=9L))
 print(groclient$get_df())

--- a/r-client/src/testscript.R
+++ b/r-client/src/testscript.R
@@ -1,0 +1,10 @@
+install.packages("reticulate",repos = "http://cran.us.r-project.org")
+library(reticulate)
+py_install("git+https://github.com/gro-intelligence/api-client.git")
+
+gro_client <- import("api.client.gro_client")
+
+groclient = gro_client$GroClient("api.gro-intelligence.com","put-your-api-token-here")
+
+groclient$add_single_data_series(dict(metric_id=5590032L, item_id=5187L, region_id=1038L, source_id=2L, frequency_id=9L))
+print(groclient$get_df())

--- a/r-client/src/testscript.R
+++ b/r-client/src/testscript.R
@@ -6,5 +6,5 @@ gro_client <- import("api.client.gro_client")
 
 groclient = gro_client$GroClient("api.gro-intelligence.com","put-your-api-token-here")
 
-groclient$add_single_data_series(dict(metric_id=5590032L, item_id=5187L, region_id=1038L, source_id=2L, frequency_id=9L))
+groclient$add_single_data_series(dict(mmetric_id=570001L, item_id=95L, region_id=1210L, source_id=2L, frequency_id=9L))
 print(groclient$get_df())


### PR DESCRIPTION
Add proof of concept example for using the Python client from within R.

Important things to note:

- The Python client is the officially-supported method. This is a use-at-your-own-risk situation. See README for if that's clear or not.
- Python still needs to be installed in order to use this, since it calls Python from within R. It's not a replacement runtime - it's an interface wrapper.
- This is implemented as a Vagrantfile and provisioning script just to show what the pre-requisites and environment requirements are. This is one possible configuration using Ubuntu 16.04 and Python 2.7.12, but there are many other possible ways to fulfill the requirements. It is not an exhaustive instruction manual.

Click “view file” to see the formatted version of the README.