### PR TITLE
fixed: no-data regions caused standardize to fail.

### DIFF
--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -67,7 +67,8 @@ class SimilarRegion(object):
         :param region_ids:
         :return: regions that are most similar to the given region id(s)
         """
-        assert region_id in self.state.mapping, "This region is not available in your configuration."
+        assert region_id in self.state.mapping, "This region is not available in your configuration or " \
+                                                "it lacks coverage in the chosen region properties."
         # list as an index to preserve dimensionality of returned data
         x = self.state.data_standardized[self.state.mapping[region_id], :]
         x = x.reshape(1, -1)

--- a/api/client/samples/similar_regions/similar_region_state.py
+++ b/api/client/samples/similar_regions/similar_region_state.py
@@ -144,6 +144,9 @@ class SimilarRegionState(object):
         # update the number of regions
         self.num_regions = len(self.inverse_mapping)
 
+        # update nonstruc from data array
+        self._create_views()
+
         # copy in from the nonstruc view
         np.copyto(self.data_standardized, self.data_nonstruc)
         mean = np.ma.average(self.data_nonstruc, axis=0)


### PR DESCRIPTION
If a region missing some region properties was added, standardize() would fail because the number of regions was updated but not the corresponding view of the array. This should fix that issue. 