### PR TITLE
CLEWS-16132 Add automatic retries

### DIFF
--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -13,11 +13,7 @@ from tornado.escape import json_decode
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
-from tornado.locks import Event
 from api.client import cfg, lib, Client
-
-rate_limit_lock = Event()
-rate_limit_lock.set()
 
 
 class BatchClient(Client):
@@ -66,9 +62,7 @@ class BatchClient(Client):
                     self._logger.warning(e.response.error, extra=log_record)
                     retry_count += 1
                     if e.code == 429:
-                        rate_limit_lock.clear()
                         time.sleep(2 ** retry_count)  # Exponential backoff
-                        rate_limit_lock.set()
                 else:
                     self._logger.error(e.response.error, extra=log_record)
                     raise Exception('Giving up on {} after {} tries. \

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -1,6 +1,6 @@
 import time
 
-#Python3 support
+# Python3 support
 try:
     # Python3
     from urllib.parse import urlencode
@@ -13,17 +13,19 @@ from tornado.escape import json_decode
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
-
+from tornado.locks import Event
 from api.client import cfg, lib, Client
+
+rate_limit_lock = Event()
+rate_limit_lock.set()
 
 
 class BatchClient(Client):
-
-    """API client with support for batch asynchronous queries. """
+    """API client with support for batch asynchronous queries."""
 
     _logger = None
     _http_client = None
-    
+
     def __init__(self, api_host, access_token):
         super(BatchClient, self).__init__(api_host, access_token)
         self._logger = lib.get_default_logger()
@@ -31,7 +33,10 @@ class BatchClient(Client):
 
     @gen.coroutine
     def get_data(self, url, headers, params=None):
-        """General 'make api request' function. Assigns headers and builds in retries and logging."""
+        """General 'make api request' function.
+
+        Assigns headers and builds in retries and logging.
+        """
         if params is not None:
             url = '{url}?{params}'.format(url=url, params=urlencode(params))
         base_log_record = dict(route=url, params=params)
@@ -40,7 +45,8 @@ class BatchClient(Client):
         while retry_count < cfg.MAX_RETRIES:
             start_time = time.time()
             http_request = HTTPRequest(url, method="GET", headers=headers,
-                                       request_timeout=cfg.TIMEOUT, connect_timeout=cfg.TIMEOUT)
+                                       request_timeout=cfg.TIMEOUT,
+                                       connect_timeout=cfg.TIMEOUT)
             data = yield self._http_client.fetch(http_request)
             elapsed_time = time.time() - start_time
             log_record = dict(base_log_record)
@@ -53,6 +59,10 @@ class BatchClient(Client):
             retry_count += 1
             if retry_count < cfg.MAX_RETRIES:
                 self._logger.warning(data.text, extra=log_record)
+                if data.status_code == 429:
+                    rate_limit_lock.clear()
+                    time.sleep(2 ** retry_count)  # Exponential backoff
+                    rate_limit_lock.set()
             else:
                 self._logger.error(data.text, extra=log_record)
                 raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(
@@ -64,27 +74,31 @@ class BatchClient(Client):
         of: item_id, metric_id, region_id, frequency_id, source_id,
         partner_region_id. Additional arguments are allowed and ignored.
         """
-        headers = {'authorization': 'Bearer ' + self.access_token }
+        headers = {'authorization': 'Bearer ' + self.access_token}
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
         resp = yield self.get_data(url, headers, params)
         raise gen.Return(json_decode(resp))
 
-    def batch_async_get_data_points(self, batched_args, output_list=None, map_result=None):
-        return self.batch_async_queue(self.get_data_points, batched_args, output_list, map_result)
+    def batch_async_get_data_points(self, batched_args, output_list=None,
+                                    map_result=None):
+        return self.batch_async_queue(self.get_data_points, batched_args,
+                                      output_list, map_result)
 
     def batch_async_queue(self, func, batched_args, output_list, map_result):
-        """
-        Asynchronously call func
+        """Asynchronously call func.
+
         :param func: function to be called on each member of batched_args
-        :param batched_args: list of keyword arguments dictionaries, one for each call to func
+        :param batched_args: list of keyword arguments dictionaries, one for
+        each call to func
         :param output_list:
         :param map_result:
         :return:
         """
         assert type(batched_args) is list, \
-            "Only argument to a batch async decorated function should be a list of a list of the individual " \
-            "non-keyword arguments being passed to the original function."
+            "Only argument to a batch async decorated function should be a \
+            list of a list of the individual non-keyword arguments being \
+            passed to the original function."
 
         # Default is identity mapping into results list.
         if not map_result:
@@ -98,7 +112,7 @@ class BatchClient(Client):
 
         @gen.coroutine
         def consumer():
-            """Consume the queue by executing func on all items in queue asynchronously."""
+            """Execute func on all items in queue asynchronously."""
             while q.qsize():
                 idx, item = q.get().result()
                 self._logger.debug('Doing work on {}'.format(idx))
@@ -116,7 +130,8 @@ class BatchClient(Client):
             for idx, item in enumerate(batched_args):
                 q.put((idx, item))
             elapsed = time.time() - lasttime
-            self._logger.info("Queued {} requests in {}  ".format(q.qsize(), elapsed))
+            self._logger.info("Queued {} requests in {}".format(q.qsize(),
+                                                                elapsed))
 
         @gen.coroutine
         def main():
@@ -129,4 +144,3 @@ class BatchClient(Client):
         IOLoop.current().run_sync(main)
 
         return output_list
-

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -84,16 +84,16 @@ def get_data(url, headers, params=None, logger=None):
     if data.status_code == 200:
       logger.debug('OK', extra=log_record)
       return data
-    if data.status_code == 429:
-      time.sleep(2 ** retry_count)  # Exponential backoff before retrying
     retry_count += 1
     log_record['tag'] = 'failed_gro_api_request'
     if retry_count < cfg.MAX_RETRIES:
       logger.warning(data.text, extra=log_record)
+      if data.status_code == 429:
+        time.sleep(2 ** retry_count)  # Exponential backoff before retrying
+      elif data.status_code == 301:
+        params = redirect(params, data.json()['data'][0])
     else:
       logger.error(data.text, extra=log_record)
-    if data.status_code == 301:
-      params = redirect(params, data.json()['data'][0])
   raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(url, retry_count, data.text))
 
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -84,6 +84,8 @@ def get_data(url, headers, params=None, logger=None):
     if data.status_code == 200:
       logger.debug('OK', extra=log_record)
       return data
+    if data.status_code == 429:
+      time.sleep(2 ** retry_count)  # Exponential backoff before retrying
     retry_count += 1
     log_record['tag'] = 'failed_gro_api_request'
     if retry_count < cfg.MAX_RETRIES:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-unicodecsv
+certifi
+chardet
+future
 numpy
 pandas
 python-dateutil
 pytz
-certifi
-chardet
 requests
+tornado
+unicodecsv
 urllib3
-future

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,17 @@ with open("requirements.txt", "r") as requirements_file:
     requirements = requirements_file.read()
 
 setuptools.setup(
-    name = "gro",
-    version = "1.19.1",
-    description = "Python client library for accessing Gro Intelligence's agricultural data platform",
-    long_description = long_description,
-    long_description_content_type = "text/markdown",
-    url = "https://github.com/gro-intelligence/api-client",
-    packages = setuptools.find_packages(),
-    python_requires = ">=2.7.6",
-    install_requires = requirements,
-    entry_points = {
-      'console_scripts': ['gro_client=api.client.gro_client:main']
+    name="gro",
+    version="1.19.1",
+    description="Python client library for accessing Gro Intelligence's "
+                "agricultural data platform",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/gro-intelligence/api-client",
+    packages=setuptools.find_packages(),
+    python_requires=">=2.7.6",
+    install_requires=requirements,
+    entry_points={
+        'console_scripts': ['gro_client=api.client.gro_client:main']
     }
 )


### PR DESCRIPTION
Tested out the BatchClient and lib.py implementations by running test scripts on dev to generate as many requests as possible in many parallel shell processes:

For batch_client, I adapted `batch_client.py`:

```python
api_client = BatchClient(API_HOST, ACCESS_TOKEN)

    # specify everything except region_id
    selection = {
        'metric_id': 860032,
        'item_id': 274,
        'source_id': 25,
        'frequency_id': 9,
        'start_date': '1998-01-01T00:00:00.000Z',
        'end_date': '1998-01-01T00:00:00.000Z'
    }

    selections = []
    for region_id in US_COUNTY_IDS:
        selection_temp = dict(selection)
        selection_temp["region_id"] = region_id
        selections.append(selection_temp)

    # make the request in a batch, asynchronous way
    output = api_client.batch_async_get_data_points(selections)

    # the output data is in the same order as the input queries.
    for county_id, data in zip(US_COUNTY_IDS, output):
        print(data)
        # some counties are missing data
        if len(data) > 0 and 'data' in data[0]:
            print("county_idx=%i produced %.0f tonnes of corn in 1998" %
                  (county_id, data[0]["value"]))
        else:
            print("county_idx=%i has no data for 1998" % county_id)
```

<img width="1440" alt="Screen Shot 2019-03-26 at 8 57 03 PM" src="https://user-images.githubusercontent.com/3478393/55035336-966d7c80-500f-11e9-802b-c6889d3001f0.png">

You can see 6 concurrent batch clients requesting data simultaneously. Without the retries, any instance of being rate limited would cause the program to fail, but with the rate limits, it waits a tick and tries again, and all 6 are able to resolve successfully, albeit with some slight delays.


And to test lib.py I used:

```python
    client = api.client.Client(API_HOST, ACCESS_TOKEN)
    i = 1
    start_time = time.time()
    num_requests = 0
    while True:
        num_requests += 1
        try:
            client.lookup('regions', i)
        except Exception as e:
            if str(e) == '429':
                print("Gave up")
            i += 1
        else:
            i += 1
        print(num_requests / (time.time() - start_time), "QPS")
```

<img width="360" alt="Screen Shot 2019-03-26 at 10 00 20 PM" src="https://user-images.githubusercontent.com/3478393/55036633-22cd6e80-5013-11e9-9fd3-c23cc2af2cc8.png">

As you can see, running 11 processes concurrently, each one performing ~2.5-3qps, I was starting to run into some rate limiting, and some processes had to wait a tick or two before proceeding but continued with an occasional unlucky "Gave Up."