### PR TITLE
Lint and add docstrings to lib module

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -19,7 +19,6 @@ def get_default_logger():
     return logger
 
 
-
 def get_access_token(api_host, user_email, user_password, logger=None):
     retry_count = 0
     if not logger:
@@ -37,7 +36,6 @@ def get_access_token(api_host, user_email, user_password, logger=None):
         retry_count += 1
     raise Exception("Giving up on get_access_token after {0} tries.".format(
         retry_count))
-
 
 
 def redirect(params, migration):
@@ -105,7 +103,6 @@ def get_data(url, headers, params=None, logger=None):
     )
 
 
-
 def get_available(access_token, api_host, entity_type):
     """List available entities of the given type.
 
@@ -116,7 +113,6 @@ def get_available(access_token, api_host, entity_type):
     headers = {'authorization': 'Bearer ' + access_token}
     resp = get_data(url, headers)
     return resp.json()['data']
-
 
 
 def list_available(access_token, api_host, selected_entities):
@@ -138,7 +134,6 @@ def list_available(access_token, api_host, selected_entities):
         raise Exception(resp.text)
 
 
-
 def lookup(access_token, api_host, entity_type, entity_id):
     """Retrieve details about a given id of type entity_type.
 
@@ -154,7 +149,6 @@ def lookup(access_token, api_host, entity_type, entity_id):
         raise Exception(resp.text)
 
 
-
 def snake_to_camel(term):
     """Convert hello_world to helloWorld.
 
@@ -163,7 +157,6 @@ def snake_to_camel(term):
     """
     camel = term.split('_')
     return ''.join(camel[:1] + list([x[0].upper()+x[1:] for x in camel[1:]]))
-
 
 
 def get_params_from_selection(**selection):
@@ -177,7 +170,6 @@ def get_params_from_selection(**selection):
                    'source_id', 'frequency_id'):
             params[snake_to_camel(key)] = value
     return params
-
 
 
 def get_crop_calendar_params(**selection):
@@ -194,7 +186,6 @@ def get_crop_calendar_params(**selection):
     return params
 
 
-
 def get_data_call_params(**selection):
     """Construct http request params from dict of entity selections.
 
@@ -208,7 +199,6 @@ def get_data_call_params(**selection):
     return params
 
 
-
 def get_data_series(access_token, api_host, **selection):
     """Get data series records for the given selection.
 
@@ -217,6 +207,13 @@ def get_data_series(access_token, api_host, **selection):
     allowed and ignored.
     """
     url = '/'.join(['https:', '', api_host, 'v2/data_series/list'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = get_params_from_selection(**selection)
+    resp = get_data(url, headers, params)
+    try:
+        return resp.json()['data']
+    except KeyError as e:
+        raise Exception(resp.text)
 
 
 def rank_series_by_source(access_token, api_host, series_list):
@@ -244,7 +241,6 @@ def rank_series_by_source(access_token, api_host, series_list):
             series_with_source = dict(series)
             series_with_source['source_id'] = source_id
             yield series_with_source
-
 
 
 def format_crop_calendar_response(resp):
@@ -305,7 +301,6 @@ def format_crop_calendar_response(resp):
     return points
 
 
-
 def get_crop_calendar_data_points(access_token, api_host, **selection):
     """Get crop calendar data.
 
@@ -318,7 +313,6 @@ def get_crop_calendar_data_points(access_token, api_host, **selection):
     params = get_crop_calendar_params(**selection)
     resp = get_data(url, headers, params)
     return format_crop_calendar_response(resp.json())
-
 
 
 def get_data_points(access_token, api_host, **selection):
@@ -338,7 +332,6 @@ def get_data_points(access_token, api_host, **selection):
     return resp.json()
 
 
-
 def universal_search(access_token, api_host, search_terms):
     """Search across all entity types for the given terms.
 
@@ -350,7 +343,6 @@ def universal_search(access_token, api_host, search_terms):
     headers = {'authorization': 'Bearer ' + access_token}
     resp = get_data(url, headers, {'q': search_terms})
     return resp.json()
-
 
 
 def search(access_token, api_host, entity_type, search_terms):
@@ -365,7 +357,6 @@ def search(access_token, api_host, entity_type, search_terms):
     headers = {'authorization': 'Bearer ' + access_token}
     resp = get_data(url, headers, {'q': search_terms})
     return resp.json()
-
 
 
 def search_and_lookup(access_token, api_host, entity_type, search_terms):
@@ -383,7 +374,6 @@ def search_and_lookup(access_token, api_host, entity_type, search_terms):
         yield lookup(access_token, api_host, entity_type, result['id'])
 
 
-
 def lookup_belongs(access_token, api_host, entity_type, entity_id):
     """Look up details of entities containing the given entity.
 
@@ -397,7 +387,6 @@ def lookup_belongs(access_token, api_host, entity_type, entity_id):
     resp = get_data(url, headers, params)
     for parent_entity_id in resp.json().get('data').get(str(entity_id), []):
         yield lookup(access_token, api_host, entity_type, parent_entity_id)
-
 
 
 def get_geo_centre(access_token, api_host, region_id):

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -22,7 +22,7 @@ REGION_LEVELS = {
     'district': 5,  # Equivalent to county in the United States
     'city': 6,
     'market': 7,
-    'group': 8,  # arbitrary grouping of regions of any level
+    'other': 8,
     'coordinate': 9
 }
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -407,8 +407,8 @@ def rank_series_by_source(access_token, api_host, series_list):
 
     Yields
     ------
-    list of dicts
-        Same dicts as the input series_list but reordered by source_id.
+    dict
+        The input series_list but reordered by source rank
 
     """
     # We sort the internal tuple representations of the dictionaries because

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -1,4 +1,9 @@
-"""This module is the base for making API calls."""
+"""Base module for making API requests.
+
+Client, GroClient, CropModel, and BatchClient all build on top of endpoints
+exposed in this module. Helper functions or shims or derivative functionality
+should appear in the client classes rather than here.
+"""
 
 from builtins import map
 from builtins import str
@@ -257,10 +262,19 @@ def lookup(access_token, api_host, entity_type, entity_id):
 
 
 def snake_to_camel(term):
-    """Convert hello_world to helloWorld.
+    """Convert a string from snake_case to camelCase.
 
     >>> snake_to_camel('hello_world')
     'helloWorld'
+
+    Parameters
+    ----------
+    term : string
+
+    Returns
+    -------
+    string
+
     """
     camel = term.split('_')
     return ''.join(camel[:1] + list([x[0].upper()+x[1:] for x in camel[1:]]))

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -157,7 +157,7 @@ def get_data(url, headers, params=None, logger=None):
         elif data.status_code == 301:
             params = redirect(params, data.json()['data'][0])
         else:
-        logger.error(data.text, extra=log_record)
+            logger.error(data.text, extra=log_record)
     raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(
         url, retry_count, data.text))
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -1,4 +1,4 @@
-"""This module is for making API calls."""
+"""This module is the base for making API calls."""
 
 from builtins import map
 from builtins import str
@@ -8,6 +8,18 @@ import requests
 import time
 
 CROP_CALENDAR_METRIC_ID = 2260063
+
+REGION_LEVELS = {
+    'world': 1,
+    'continent': 2,
+    'country': 3,
+    'province': 4,  # Equivalent to state in the United States
+    'district': 5,  # Equivalent to county in the United States
+    'city': 6,
+    'market': 7,
+    'group': 8,  # arbitrary grouping of regions of any level
+    'coordinate': 9
+}
 
 
 def get_default_logger():
@@ -388,7 +400,7 @@ def get_data_series(access_token, api_host, **selection):
     resp = get_data(url, headers, params)
     try:
         return resp.json()['data']
-    except KeyError as e:
+    except KeyError:
         raise Exception(resp.text)
 
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -1,354 +1,427 @@
+"""This module is for making API calls."""
+
 from builtins import map
 from builtins import str
 from api.client import cfg
 import logging
 import requests
-import sys
 import time
-from datetime import datetime
 
 CROP_CALENDAR_METRIC_ID = 2260063
 
+
 def get_default_logger():
-  logger = logging.getLogger(__name__)
-  logger.setLevel(cfg.DEFAULT_LOG_LEVEL)
-  if not logger.handlers:
-    stderr_handler = logging.StreamHandler()
-    logger.addHandler(stderr_handler)
-  return logger
+    logger = logging.getLogger(__name__)
+    logger.setLevel(cfg.DEFAULT_LOG_LEVEL)
+    if not logger.handlers:
+        stderr_handler = logging.StreamHandler()
+        logger.addHandler(stderr_handler)
+    return logger
+
 
 def get_access_token(api_host, user_email, user_password, logger=None):
-  retry_count = 0
-  if not logger:
-    logger = get_default_logger()
-  while retry_count < cfg.MAX_RETRIES:
-    get_api_token = requests.post('https://' + api_host + '/api-token',
-                          data = {"email": user_email, "password": user_password})
-    if get_api_token.status_code == 200:
-      logger.debug("Authentication succeeded in get_access_token")
-      return get_api_token.json()['data']['accessToken']
-    else:
-      logger.warning("Error in get_access_token: {}".format(get_api_token.body))
-    retry_count += 1
-  raise Exception("Giving up on get_access_token after {0} tries.".format(retry_count))
+    retry_count = 0
+    if not logger:
+        logger = get_default_logger()
+    while retry_count < cfg.MAX_RETRIES:
+        get_api_token = requests.post('https://' + api_host + '/api-token',
+                                      data={"email": user_email,
+                                            "password": user_password})
+        if get_api_token.status_code == 200:
+            logger.debug("Authentication succeeded in get_access_token")
+            return get_api_token.json()['data']['accessToken']
+        else:
+            logger.warning("Error in get_access_token: {}".format(
+                get_api_token.body))
+        retry_count += 1
+    raise Exception("Giving up on get_access_token after {0} tries.".format(
+        retry_count))
+
 
 def redirect(params, migration):
-  """
-  Update query parameters to follow a redirection response from the API before
-  trying again.
+    """Update query parameters to follow a redirection response from the API.
 
-  >>> redirect( {'metricId': 14, 'sourceId': 2, 'itemId': 145},
-  ...           {'old_metric_id': 14, 'new_metric_id': 15,
-  ...            'old_item_id': -1, 'new_item_id': -1, 'source_id': 2})
-  {'sourceId': 2, 'itemId': 145, 'metricId': 15}
+    >>> redirect( {'metricId': 14, 'sourceId': 2, 'itemId': 145},
+    ...           {'old_metric_id': 14, 'new_metric_id': 15, 'source_id': 2})
+    {'sourceId': 2, 'itemId': 145, 'metricId': 15}
 
-  Parameters
-  ----------
-  params : dict
-    The original parameters provided to the API request
-  migration : dict
-    The body of the 301 response indicating which of the inputs have been
-    migrated and what values they have been migrated to
+    Parameters
+    ----------
+    params : dict
+        The original parameters provided to the API request
+    migration : dict
+        The body of the 301 response indicating which of the inputs have been
+        migrated and what values they have been migrated to
 
-  Returns
-  -------
-  params : dict
-    The mutated params object with values replaced according to the redirection
-    instructions provided by the API
-  """
+    Returns
+    -------
+    params : dict
+        The mutated params object with values replaced according to the
+        redirection instructions provided by the API
 
-  for key in migration:
-    split_key = key.split('_')
-    if split_key[0] == 'new' and migration[key] > -1:
-      params[snake_to_camel('_'.join([split_key[1], 'id']))] = migration[key]
-  return params
+    """
+    for migration_key in migration:
+        split_mig_key = migration_key.split('_')
+        if split_mig_key[0] == 'new':
+            param_key = snake_to_camel('_'.join([split_mig_key[1], 'id']))
+            params[param_key] = migration[migration_key]
+    return params
+
 
 def get_data(url, headers, params=None, logger=None):
-  """General 'make api request' function. Assigns headers and builds in retries and logging."""
-  base_log_record = dict(route=url, params=params)
-  retry_count = 0
-  if not logger:
-    logger = get_default_logger()
-  logger.debug(url)
-  logger.debug(params)
-  while retry_count < cfg.MAX_RETRIES:
-    start_time = time.time()
-    data = requests.get(url, params=params, headers=headers, timeout=None)
-    elapsed_time = time.time() - start_time
-    log_record = dict(base_log_record)
-    log_record['elapsed_time_in_ms'] = 1000 * elapsed_time
-    log_record['retry_count'] = retry_count
-    log_record['status_code'] = data.status_code
-    if data.status_code == 200:
-      logger.debug('OK', extra=log_record)
-      return data
-    retry_count += 1
-    log_record['tag'] = 'failed_gro_api_request'
-    if retry_count < cfg.MAX_RETRIES:
-      logger.warning(data.text, extra=log_record)
-    else:
-      logger.error(data.text, extra=log_record)
-    if data.status_code == 301:
-      params = redirect(params, data.json()['data'][0])
-  raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(url, retry_count, data.text))
+    """General 'make api request' function.
+
+    Assigns headers and builds in retries and logging.
+    """
+    base_log_record = dict(route=url, params=params)
+    retry_count = 0
+    if not logger:
+        logger = get_default_logger()
+    logger.debug(url)
+    logger.debug(params)
+    while retry_count < cfg.MAX_RETRIES:
+        start_time = time.time()
+        data = requests.get(url, params=params, headers=headers, timeout=None)
+        elapsed_time = time.time() - start_time
+        log_record = dict(base_log_record)
+        log_record['elapsed_time_in_ms'] = 1000 * elapsed_time
+        log_record['retry_count'] = retry_count
+        log_record['status_code'] = data.status_code
+        if data.status_code == 200:
+            logger.debug('OK', extra=log_record)
+            return data
+        retry_count += 1
+        log_record['tag'] = 'failed_gro_api_request'
+        if retry_count < cfg.MAX_RETRIES:
+            logger.warning(data.text, extra=log_record)
+        else:
+            logger.error(data.text, extra=log_record)
+        if data.status_code == 301:
+            params = redirect(params, data.json()['data'][0])
+    raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(
+        url, retry_count, data.text)
+    )
+
 
 def get_available(access_token, api_host, entity_type):
-  """Given an entity_type, which is one of 'items', 'metrics',
-    'regions', returns a JSON dict with the list of available entities
-    of the given type.
+    """List available entities of the given type.
+
+    Given an entity_type, which is one of 'items', 'metrics',
+    'regions', returns a JSON dict.
     """
-  url = '/'.join(['https:', '', api_host, 'v2', entity_type])
-  headers = {'authorization': 'Bearer ' + access_token}
-  resp = get_data(url, headers)
-  return resp.json()['data']
+    url = '/'.join(['https:', '', api_host, 'v2', entity_type])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers)
+    return resp.json()['data']
+
 
 def list_available(access_token, api_host, selected_entities):
-  """List available entities given some selected entities. Given a dict
-  of selected entity ids of the form { <entity_type>: <entity_id>,
-  ...}, returns a list of dictionaries representing available {
-  item_id: ..., metric_id: ... , region_id: ... ,} for which data
-  series are available which satisfy the input selection.
-  """
-  url = '/'.join(['https:', '', api_host, 'v2/entities/list'])
-  headers = {'authorization': 'Bearer ' + access_token}
-  params = dict([(snake_to_camel(key), value)
-                 for (key, value) in list(selected_entities.items())])
-  resp = get_data(url, headers, params)
-  try:
-    return resp.json()['data']
-  except KeyError as e:
-    raise Exception(resp.text)
+    """List available entities given some selected entities.
+
+    Given a dict of selected entity ids of the form
+    { <entity_type>: <entity_id>, ...}, returns a list of dictionaries
+    representing available {item_id: ..., metric_id: ... , region_id: ... ,}
+    for which data series are available which satisfy the input selection.
+    """
+    url = '/'.join(['https:', '', api_host, 'v2/entities/list'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = dict([(snake_to_camel(key), value)
+                   for (key, value) in list(selected_entities.items())])
+    resp = get_data(url, headers, params)
+    try:
+        return resp.json()['data']
+    except KeyError:
+        raise Exception(resp.text)
+
 
 def lookup(access_token, api_host, entity_type, entity_id):
-  """Given an entity_type, which is one of 'items', 'metrics',
-  'regions', 'units', or 'sources', returns a JSON dict with the
-  list of available entities of the given type.
-  """
-  url = '/'.join(['https:', '', api_host, 'v2', entity_type, str(entity_id)])
-  headers = {'authorization': 'Bearer ' + access_token}
-  resp = get_data(url, headers)
-  try:
-    return resp.json()['data']
-  except KeyError as e:
-    raise Exception(resp.text)
+    """Retrieve details about a given id of type entity_type.
+
+    entity_type is one of 'items', 'metrics', 'regions', 'units', or 'sources'.
+    Returns a JSON dict with the list of available entities of the given type.
+    """
+    url = '/'.join(['https:', '', api_host, 'v2', entity_type, str(entity_id)])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers)
+    try:
+        return resp.json()['data']
+    except KeyError:
+        raise Exception(resp.text)
+
 
 def snake_to_camel(term):
-  """Converts hello_world to helloWorld."""
-  camel = term.split('_')
-  return ''.join(camel[:1] + list([x[0].upper()+x[1:] for x in camel[1:]]))
+    """Convert hello_world to helloWorld.
+
+    >>> snake_to_camel('hello_world')
+    helloWorld
+    """
+    camel = term.split('_')
+    return ''.join(camel[:1] + list([x[0].upper()+x[1:] for x in camel[1:]]))
+
 
 def get_params_from_selection(**selection):
-  """Construct http request params from dict of entity selections. For use with get_data_series()
-  and rank_series_by_source().
-  """
-  params = { }
-  for key, value in list(selection.items()):
-    if key in ('region_id', 'partner_region_id', 'item_id', 'metric_id', 'source_id', 'frequency_id'):
-      params[snake_to_camel(key)] = value
-  return params
+    """Construct http request params from dict of entity selections.
+
+    For use with get_data_series() and rank_series_by_source().
+    """
+    params = {}
+    for key, value in list(selection.items()):
+        if key in ('region_id', 'partner_region_id', 'item_id', 'metric_id',
+                   'source_id', 'frequency_id'):
+            params[snake_to_camel(key)] = value
+    return params
+
 
 def get_crop_calendar_params(**selection):
-  """Construct http request params from dict of entity selections. Only region and item are required
-  since metric/item/source/frequency all have default values and start/end date are not allowed
-  inputs since crop calendars are static.
-  """
-  params = { }
-  for key, value in list(selection.items()):
-    if key in ('region_id', 'item_id'):
-      params[snake_to_camel(key)] = value
-  return params
+    """Construct http request params from dict of entity selections.
+
+    Only region and item are required since metric/item/source/frequency all
+    have default values and start/end date are not allowed inputs since crop
+    calendars are static.
+    """
+    params = {}
+    for key, value in list(selection.items()):
+        if key in ('region_id', 'item_id'):
+            params[snake_to_camel(key)] = value
+    return params
+
 
 def get_data_call_params(**selection):
-  """Construct http request params from dict of entity selections. For use with get_data_points().
-  """
-  params = get_params_from_selection(**selection)
-  for key, value in list(selection.items()):
-    if key in ('source_id', 'frequency_id', 'start_date', 'end_date', 'show_revisions'):
-      params[snake_to_camel(key)] = value
-  return params
+    """Construct http request params from dict of entity selections.
+
+    For use with get_data_points().
+    """
+    params = get_params_from_selection(**selection)
+    for key, value in list(selection.items()):
+        if key in ('source_id', 'frequency_id', 'start_date', 'end_date',
+                   'show_revisions'):
+            params[snake_to_camel(key)] = value
+    return params
+
 
 def get_data_series(access_token, api_host, **selection):
-  """Get data series records for the given selection of entities.  which
-  is some or all of: item_id, metric_id, region_id, frequency_id,
-  source_id, partner_region_id. Additional arguments are allowed and
-  ignored.
-  """
-  url = '/'.join(['https:', '', api_host, 'v2/data_series/list'])
-  headers = {'authorization': 'Bearer ' + access_token}
-  params = get_params_from_selection(**selection)
-  resp = get_data(url, headers, params)
-  try:
-    return resp.json()['data']
-  except KeyError as e:
-    raise Exception(resp.text)
+    """Get data series records for the given selection.
+
+    Selections are entities including: item_id, metric_id, region_id,
+    frequency_id, source_id, partner_region_id. Additional arguments are
+    allowed and ignored.
+    """
+    url = '/'.join(['https:', '', api_host, 'v2/data_series/list'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = get_params_from_selection(**selection)
+    resp = get_data(url, headers, params)
+    try:
+        return resp.json()['data']
+    except KeyError:
+        raise Exception(resp.text)
+
 
 def rank_series_by_source(access_token, api_host, series_list):
-  """Given a list of series, return them in source-ranked order: such
-  that if there are multiple sources for the same selection, the
-  prefered soruce comes first. Differences other than source_id are
-  not affected.
-  """
-  # We sort the internal tuple representations of the dictionaries because otherwise when we call set()
-  # we end up with duplicates if iteritems() returns a different order for the same dictionary. See
-  # test case...
-  selections_sorted = set(tuple(sorted(
-    [k_v for k_v in iter(list(single_series.items())) if k_v[0] != 'source_id'],
-    key=lambda x: x[0])) for single_series in series_list)
+    """Given a list of series, return them in source-ranked order.
 
-  for series in map(dict, selections_sorted):
-    url = '/'.join(['https:', '', api_host, 'v2/available/sources'])
-    headers = {'authorization': 'Bearer ' + access_token}
-    params = dict((k + 's', v) for k, v in iter(list(
-      get_params_from_selection(**series).items())))
-    source_ids = get_data(url, headers, params).json()
-    for source_id in source_ids:
-      # Make a copy to avoid passing the same reference each time.
-      series_with_source = dict(series)
-      series_with_source['source_id'] = source_id
-      yield series_with_source
+    If there are multiple sources for the same selection, the prefered soruce
+    comes first. Differences other than source_id are not affected.
+    """
+    # We sort the internal tuple representations of the dictionaries because
+    # otherwise when we call set() we end up with duplicates if iteritems()
+    # returns a different order for the same dictionary. See test case...
+    selections_sorted = set(tuple(sorted(
+        [k_v for k_v in iter(list(single_series.items())) if k_v[0] !=
+            'source_id'],
+        key=lambda x: x[0])) for single_series in series_list)
+
+    for series in map(dict, selections_sorted):
+        url = '/'.join(['https:', '', api_host, 'v2/available/sources'])
+        headers = {'authorization': 'Bearer ' + access_token}
+        params = dict((k + 's', v) for k, v in iter(list(
+            get_params_from_selection(**series).items())))
+        source_ids = get_data(url, headers, params).json()
+        for source_id in source_ids:
+            # Make a copy to avoid passing the same reference each time.
+            series_with_source = dict(series)
+            series_with_source['source_id'] = source_id
+            yield series_with_source
+
 
 def format_crop_calendar_response(resp):
-  """Makes the v2/cropcalendar/data output a similar format to the normal /v2/data output. Splits
-  the one point with plantingStartDate/plantingEndDate/harvestingStartDate/harvestingEndDate into
-  two distinct points with start/end where the value is the state of the crop as a string.
-  """
-  points = []
-  for point in resp:
-    # A single point may have multiple data entries if there are multiple harvests
-    for dataEntry in point['data']:
-      # Some start/end dates can be undefined (ex: {regionId: 12314, itemId: 95} - Wheat in Alta,
-      # Russia). Those are returned as empty strings, so here I am checking for that and replacing
-      # those cases with Nones. Also, in some cases both start AND end are undefined, in which
-      # case I am excluding the data point entirely.
-      if(dataEntry['plantingStartDate'] != '' or dataEntry['plantingEndDate'] != ''):
-        points.append({
-          u'input_unit_scale': None,
-          u'region_id': point['regionId'],
-          u'end_date': (dataEntry['plantingEndDate'] if dataEntry['plantingEndDate'] != '' else None),
-          u'input_unit_id': None,
-          u'value': 'planting',
-          u'frequency_id': point['frequencyId'],
-          u'available_date': None,
-          u'item_id': point['itemId'],
-          u'reporting_date': None,
-          u'start_date': (dataEntry['plantingStartDate'] if dataEntry['plantingStartDate'] != '' else None),
-          u'metric_id': point['metricId']
-        })
-      if(dataEntry['harvestingStartDate'] != '' or dataEntry['harvestingEndDate'] != ''):
-        points.append({
-          u'input_unit_scale': None,
-          u'region_id': point['regionId'],
-          u'end_date': (dataEntry['harvestingEndDate'] if dataEntry['harvestingEndDate'] != '' else None),
-          u'input_unit_id': None,
-          u'value': 'harvesting',
-          u'frequency_id': point['frequencyId'],
-          u'available_date': None,
-          u'item_id': point['itemId'],
-          u'reporting_date': None,
-          u'start_date': (dataEntry['harvestingStartDate'] if dataEntry['harvestingStartDate'] != '' else None),
-          u'metric_id': point['metricId']
-        })
-  return points
+    """Make cropcalendar output a similar format to the normal data output.
+
+    Splits the one point with plantingStartDate/plantingEndDate/
+    harvestingStartDate/harvestingEndDate into two distinct points with
+    start/end where the value is the state of the crop as a string.
+    """
+    points = []
+    for point in resp:
+        # A single point may have multiple data entries if there are multiple
+        # harvests
+        for dataEntry in point['data']:
+            # Some start/end dates can be undefined (ex: {regionId: 12314,
+            # itemId: 95} - Wheat in Alta, Russia). Those are returned as empty
+            # strings, so here I am checking for that and replacing those cases
+            # with Nones. Also, in some cases both start AND end are undefined,
+            # in which case I am excluding the data point entirely.
+            if (dataEntry['plantingStartDate'] != '' or
+                    dataEntry['plantingEndDate'] != ''):
+                points.append({
+                    u'input_unit_scale': None,
+                    u'region_id': point['regionId'],
+                    u'end_date': (dataEntry['plantingEndDate']
+                                  if dataEntry['plantingEndDate'] != ''
+                                  else None),
+                    u'input_unit_id': None,
+                    u'value': 'planting',
+                    u'frequency_id': point['frequencyId'],
+                    u'available_date': None,
+                    u'item_id': point['itemId'],
+                    u'reporting_date': None,
+                    u'start_date': (dataEntry['plantingStartDate']
+                                    if dataEntry['plantingStartDate'] != ''
+                                    else None),
+                    u'metric_id': point['metricId']
+                })
+            if (dataEntry['harvestingStartDate'] != ''
+                    or dataEntry['harvestingEndDate'] != ''):
+                points.append({
+                    u'input_unit_scale': None,
+                    u'region_id': point['regionId'],
+                    u'end_date': (dataEntry['harvestingEndDate']
+                                  if dataEntry['harvestingEndDate'] != ''
+                                  else None),
+                    u'input_unit_id': None,
+                    u'value': 'harvesting',
+                    u'frequency_id': point['frequencyId'],
+                    u'available_date': None,
+                    u'item_id': point['itemId'],
+                    u'reporting_date': None,
+                    u'start_date': (dataEntry['harvestingStartDate']
+                                    if dataEntry['harvestingStartDate'] != ''
+                                    else None),
+                    u'metric_id': point['metricId']
+                })
+    return points
+
 
 def get_crop_calendar_data_points(access_token, api_host, **selection):
-  """Helper function for getting crop calendar data. Has different input/output from the regular
-  /v2/data call, so this normalizes the interface and output format to make compatible
-  get_data_points().
-  """
-  headers = {'authorization': 'Bearer ' + access_token }
-  url = '/'.join(['https:', '', api_host, 'v2/cropcalendar/data'])
-  params = get_crop_calendar_params(**selection)
-  resp = get_data(url, headers, params)
-  return format_crop_calendar_response(resp.json())
+    """Get crop calendar data.
+
+    Has different input/output from the regular /v2/data call, so this
+    normalizes the interface and output format to make compatible
+    get_data_points().
+    """
+    headers = {'authorization': 'Bearer ' + access_token}
+    url = '/'.join(['https:', '', api_host, 'v2/cropcalendar/data'])
+    params = get_crop_calendar_params(**selection)
+    resp = get_data(url, headers, params)
+    return format_crop_calendar_response(resp.json())
+
 
 def get_data_points(access_token, api_host, **selection):
-  """Get all the data points for a given selection, which is some or all
-  of: item_id, metric_id, region_id, frequency_id, source_id,
-  partner_region_id. Additional arguments are allowed and ignored.
-  """
-  if(selection['metric_id'] == CROP_CALENDAR_METRIC_ID):
-    return get_crop_calendar_data_points(access_token, api_host, **selection)
+    """Get all the data points for a given selection.
 
-  headers = {'authorization': 'Bearer ' + access_token }
-  url = '/'.join(['https:', '', api_host, 'v2/data'])
-  params = get_data_call_params(**selection)
-  resp = get_data(url, headers, params)
-  return resp.json()
+    Selections are some or all of: item_id, metric_id, region_id, frequency_id,
+    source_id, partner_region_id. Additional arguments are allowed and ignored.
+    """
+    if(selection['metric_id'] == CROP_CALENDAR_METRIC_ID):
+        return get_crop_calendar_data_points(access_token, api_host,
+                                             **selection)
+
+    headers = {'authorization': 'Bearer ' + access_token}
+    url = '/'.join(['https:', '', api_host, 'v2/data'])
+    params = get_data_call_params(**selection)
+    resp = get_data(url, headers, params)
+    return resp.json()
+
 
 def universal_search(access_token, api_host, search_terms):
-  """Search across all entity types for the given terms.  Returns an a
-  list of [id, entity_type] pairs, e.g.: [[5604, u'item'], [10204,
-  u'item'], [410032, u'metric'], ....]
-  """
-  url_pieces = ['https:', '', api_host, 'v2/search']
-  url = '/'.join(url_pieces)
-  headers = {'authorization': 'Bearer ' + access_token }
-  resp = get_data(url, headers, {'q': search_terms})
-  return resp.json()
+    """Search across all entity types for the given terms.
+
+    Returns a list of [id, entity_type] pairs, e.g.: [[5604, u'item'], [10204,
+    u'item'], [410032, u'metric'], ....]
+    """
+    url_pieces = ['https:', '', api_host, 'v2/search']
+    url = '/'.join(url_pieces)
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers, {'q': search_terms})
+    return resp.json()
+
 
 def search(access_token, api_host, entity_type, search_terms):
-  """Given an entity_type, which is one of 'items', 'metrics',
-  'regions', performs a search for the given terms. Returns a list of
-  dictionaries with individual entities, e.g.: [{u'id': 5604}, {u'id':
-  10204}, {u'id': 10210}, ....]
-  """
-  url = '/'.join(['https:', '', api_host, 'v2/search', entity_type])
-  headers = {'authorization': 'Bearer ' + access_token }
-  resp = get_data(url, headers, {'q': search_terms})
-  return resp.json()
+    """Search for the given search term.
+
+    Given an entity_type, which is one of 'items', 'metrics',
+    'regions', perform a search for the given terms. Returns a list of
+    dictionaries with individual entities, e.g.: [{u'id': 5604}, {u'id':
+    10204}, {u'id': 10210}, ....]
+    """
+    url = '/'.join(['https:', '', api_host, 'v2/search', entity_type])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers, {'q': search_terms})
+    return resp.json()
+
 
 def search_and_lookup(access_token, api_host, entity_type, search_terms):
-  """Does a search for the given search terms, and for each result
-  yields a dict of the entity and it's properties:
-     { 'id': <integer id of entity, unique within this entity type>,
-       'name':  <string canonical name>
-       'contains': <array of ids of entities that are contained in this one>,
-       ....
-       <other properties> }
-  """
-  search_results = search(access_token, api_host, entity_type, search_terms)
-  for result in search_results:
-    yield lookup(access_token, api_host, entity_type, result['id'])
+    """Search for the given search terms and look up their details.
+
+    For each result, yield a dict of the entity and it's properties:
+    { 'id': <integer id of entity, unique within this entity type>,
+        'name':    <string canonical name>
+        'contains': <array of ids of entities that are contained in this one>,
+        ....
+        <other properties> }
+    """
+    search_results = search(access_token, api_host, entity_type, search_terms)
+    for result in search_results:
+        yield lookup(access_token, api_host, entity_type, result['id'])
+
 
 def lookup_belongs(access_token, api_host, entity_type, entity_id):
-  """Given an entity_type, which is one of 'items', 'metrics',
-  'regions', and id, generates a list of JSON dicts of entities it
-  belongs to.
-  """
-  url = '/'.join(['https:', '', api_host, 'v2', entity_type, 'belongs-to'])
-  params = { 'ids': str(entity_id) }
-  headers = {'authorization': 'Bearer ' + access_token}
-  resp = get_data(url, headers, params)
-  for parent_entity_id in resp.json().get('data').get(str(entity_id), []):
-    yield lookup(access_token, api_host, entity_type, parent_entity_id)
+    """Look up details of entities containing the given entity.
+
+    Given an entity_type, which is one of 'items', 'metrics',
+    'regions', and id, generates a list of JSON dicts of entities it
+    belongs to.
+    """
+    url = '/'.join(['https:', '', api_host, 'v2', entity_type, 'belongs-to'])
+    params = {'ids': str(entity_id)}
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers, params)
+    for parent_entity_id in resp.json().get('data').get(str(entity_id), []):
+        yield lookup(access_token, api_host, entity_type, parent_entity_id)
+
 
 def get_geo_centre(access_token, api_host, region_id):
-  """Given a region ID, returns the geographic centre in degrees lat/lon."""
-  url = '/'.join(['https:', '', api_host, 'v2/geocentres?regionIds=' + str(region_id)])
-  headers = {'authorization': 'Bearer ' + access_token}
-  resp = get_data(url, headers)
-  return resp.json()["data"]
+    """Given a region ID, return the geographic centre in degrees lat/lon."""
+    url = '/'.join(['https:', '', api_host, 'v2/geocentres?regionIds=' +
+                    str(region_id)])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers)
+    return resp.json()["data"]
 
-def get_descendant_regions(access_token, api_host, region_id, descendant_level):
-  """Given any region by id, recursively gets all the descendant regions
-  that are of the specified level. 
 
-  This takes advantage of the assumption that region graph is
-  acyclic. This will only traverse ordered region levels (strictly
-  increasing region level id) and thus skips non-administrative region
-  levels.
-  """
-  descendants = []
-  region = lookup(access_token, api_host, 'regions', region_id)
-  for member_id in region['contains']:
-    member = lookup(access_token, api_host, 'regions', member_id)
-    if descendant_level == member['level']:
-      descendants.append(member)
-    elif member['level'] < descendant_level:
-      descendants += get_descendant_regions(
-        access_token, api_host, member_id, descendant_level)
-  return descendants
+def get_descendant_regions(access_token, api_host, region_id,
+                           descendant_level):
+    """Look up details of regions of the given level contained by a region.
+
+    Given any region by id, recursively get all the descendant regions
+    that are of the specified level.
+
+    This takes advantage of the assumption that region graph is
+    acyclic. This will only traverse ordered region levels (strictly
+    increasing region level id) and thus skips non-administrative region
+    levels.
+    """
+    descendants = []
+    region = lookup(access_token, api_host, 'regions', region_id)
+    for member_id in region['contains']:
+        member = lookup(access_token, api_host, 'regions', member_id)
+        if descendant_level == member['level']:
+            descendants.append(member)
+        elif member['level'] < descendant_level:
+            descendants += get_descendant_regions(
+                access_token, api_host, member_id, descendant_level)
+    return descendants
+
 
 if __name__ == "__main__":
-  import doctest
-  doctest.testmod()
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
This PR does three things:

1. Modify code style so the lib.py module is compliant with flake8, pep8, pylint, and pydocstyle
2. Add numpy-style docstrings to all functions in the lib.py module https://numpydoc.readthedocs.io/en/latest/format.html#documenting-constants
3. Add doctest unit tests to all functions that do not need any API mocking

Run tests using `python lib.py -v` as noted in the comment here: https://github.com/gro-intelligence/api-client/compare/lint-lib?expand=1#diff-7ed38827a2c4e58f0dd776f8639dc95cR820