### PR TITLE
CLEWS-16544 Remove user_email quotes from gro_client step

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In addition, optionally you can:
 You can use the gro_client command line tool to request an authentication token. Note that you will be prompted to enter a password.
 
 ```sh
-gro_client --user_email='email@example.com' --print_token
+gro_client --user_email=email@example.com --print_token
 ```
 
 This token is used throughout the Gro API client code, wherever authentication is required.


### PR DESCRIPTION
Tested in: MacOS bash, Ubuntu bash, Anaconda Prompt (on Windows), Powershell, and Windows Command Prompt. All work without quotes, but Anaconda Prompt and Windows Command Prompt both do not work with quotes.