### PR TITLE
Fix get_df Python 3 compatibility

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -12,6 +12,7 @@ For more information use --help
 """
 
 from __future__ import print_function
+from builtins import zip
 from builtins import str
 from random import random
 import argparse
@@ -72,8 +73,7 @@ class GroClient(Client):
                 tmp.start_date = pandas.to_datetime(tmp.start_date)
             if self._data_frame is None:
                 self._data_frame = tmp
-                self._data_frame.set_index(filter(lambda col: col in tmp.columns,
-                                                  DATA_POINTS_UNIQUE_COLS))
+                self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
             else:
                 self._data_frame = self._data_frame.merge(tmp, how='outer')
         return self._data_frame


### PR DESCRIPTION
https://github.com/gro-intelligence/api-client/pull/60/files introduced a Python breaking change in the `get_df()` function.

With this test script

```python
import os
from api.client.gro_client import GroClient

API_HOST = 'api.gro-intelligence.com'
ACCESS_TOKEN=os.environ['GROAPI_TOKEN']

def main():
    client = GroClient(API_HOST, ACCESS_TOKEN)
    client.add_single_data_series({
        'metric_id': 170037,
        'item_id': 270,
        'region_id': 1215,
        'source_id': 32,
        'frequency_id': 9,
        'start_date': '2019-01-01',
        'end_date': '2019-12-31'
    })
    client.get_df()

if __name__ == "__main__":
    main()
```

Before this fix:

```shell
Added {'metric_id': 170037, 'item_id': 270, 'region_id': 1215, 'source_id': 32, 'frequency_id': 9, 'start_date': '2019-01-01', 'end_date': '2019-12-31'}
Traceback (most recent call last):
  File "/Users/john/.local/share/virtualenvs/api-work-2lr6jHLN/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 2657, in get_loc
    return self._engine.get_loc(key)
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 132, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1601, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1608, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: <filter object at 0x1172079b0>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "quick_start.py", line 21, in <module>
    main()
  File "quick_start.py", line 18, in main
    client.get_df()
  File "/Users/john/api-client/api/client/gro_client.py", line 75, in get_df
    self._data_frame.set_index(filter(lambda col: col in tmp.columns, DATA_POINTS_UNIQUE_COLS))
  File "/Users/john/.local/share/virtualenvs/api-work-2lr6jHLN/lib/python3.7/site-packages/pandas/core/frame.py", line 4193, in set_index
    del frame[c]
  File "/Users/john/.local/share/virtualenvs/api-work-2lr6jHLN/lib/python3.7/site-packages/pandas/core/generic.py", line 3315, in __delitem__
    self._data.delete(key)
  File "/Users/john/.local/share/virtualenvs/api-work-2lr6jHLN/lib/python3.7/site-packages/pandas/core/internals/managers.py", line 985, in delete
    indexer = self.items.get_loc(item)
  File "/Users/john/.local/share/virtualenvs/api-work-2lr6jHLN/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 2659, in get_loc
    return self._engine.get_loc(self._maybe_cast_indexer(key))
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 132, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1601, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1608, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: <filter object at 0x1172079b0>
```

After:

```shell
Added {'metric_id': 170037, 'item_id': 270, 'region_id': 1215, 'source_id': 32, 'frequency_id': 9, 'start_date': '2019-01-01', 'end_date': '2019-12-31'}
```