### PR TITLE
CLEWS-17697 Update README examples and token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<p align="center"><img width=8% src="https://gro-intelligence.com/images/logo.jpg"></p>
+
 # Gro API Client
 
 https://www.gro-intelligence.com/products/gro-api
@@ -11,81 +13,36 @@ Client library for accessing Gro Intelligence's agricultural data platform.
 
 ## Install Gro API client packages
 
-There are two installation methods: using pip, or using git. 
-
-### Install with pip install (preferred)
-
 ```sh
-pip install git+https://github.com/gro-intelligence/api-client.git [--target=<your-gro-path>]
+pip install git+https://github.com/gro-intelligence/api-client.git
 ```
-
-If you don't specify your gro installation path, it will be the local [site-packages]( https://stackoverflow.com/questions/31384639/what-is-pythons-site-packages-directory) directory.
-
-### Install with git clone 
-
-```
-git clone https://github.com/gro-intelligence/api-client.git  [<your-gro-path>]
-```
-If you don't specify your gro installation path, it will be the current directory.
-In addition, optionally you can:
-
-1. [Set `PYTHONPATH=<your-gro-path>` as an environment variable](https://www.techwalla.com/articles/how-to-set-your-python-path)
-
-2. Make `gro_client` an alias for `python <your-gro-path>/gro_client.py`
-
 
 ## Gro API authentication token
 
-### Getting a token
+Use the Gro web application to retrieve an authentication token (instructions are in the wiki [here](https://github.com/gro-intelligence/api-client/wiki/Authentication-Tokens#11-using-the-gro-web-application-preferred)).
 
-You can use the gro_client command line tool to request an authentication token. Note that you will be prompted to enter a password.
+### Saving your token as an environment variable (optional)
 
-```sh
-gro_client --user_email=email@example.com --print_token
-```
-
-This token is used throughout the Gro API client code, wherever authentication is required.
-
-Gro authentication tokens *may* expire or be reset by the administrator,
-depending on your account status. You can re-run the above command to get a new one 
-if your previous one has expired.
-
-### Saving your token as an environment variable
-
-If you don't want to enter a password or token each time, you can save
-the token as an environment variable. Please consult your OS or IDE documentation for information on how to set environment variables, e.g. [setting environment variables in Windows Powershell](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-6) and [Mac OS X/Linux](https://apple.stackexchange.com/questions/106778/how-do-i-set-environment-variables-on-os-x).  In some of the sample code, it is assumed that you have the token saved to your environment variables as GROAPI_TOKEN. 
+If you don't want to enter a password or token each time, you can save the token as an environment variable. Please consult your OS or IDE documentation for information on how to set environment variables, e.g. [setting environment variables in Windows Powershell](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-6) and [Mac OS X/Linux](https://apple.stackexchange.com/questions/106778/how-do-i-set-environment-variables-on-os-x). In some of the sample code, it is assumed that you have the token saved to your environment variables as `GROAPI_TOKEN`.
 
 ## Examples
 
 Navigate to [api/client/samples/](api/client/samples/) folder and try executing the provided examples.
 
-Try [quick_start.py](api/client/samples/quick_start.py)
+1. Try [quick_start.py](api/client/samples/quick_start.py).
 
 ```sh
-cd your-gro-path/api-client/api/client/samples/
-
 python quick_start.py
 ```
-Now should be able to find a sample output csv file at: `gro_client_output.csv`
 
-A more advanced example is [sugar.py](api/client/samples/crop_models/sugar.py)
+If the API client is installed and your authentication token is set, a csv file called `gro_client_output.csv` should be created in the directory where the script was run.
 
-```sh
-cd your-gro-path/api-client/api/client/samples/crop_models/
-python sugar.py
-```
-
-You can also use the Gro CLI as a quick and easy way to request a single data series right on the command line. You can either provide your email and enter a password when prompted, or you can provide your --token to avoid typing a password every time:
+2. Try out [soybeans.py](api/client/samples/crop_models/soybeans.py) to see the crop weighted series feature in action:
 
 ```sh
-gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@expample.com'
-Password: <enter password when prompted>
-
-or
-
-gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --token='token-generated-in-setup-steps'
+python crop_modles/soybeans.py
 ```
 
-This will choose the first matching data series and output the results to a `gro_client_output.csv` file in your current directory.
+3. See [brazil_soybeans.ipynb](https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/crop_models/brazil_soybeans.ipynb) for a longer, more detailed demonstration of many of the API's capabilities in a Jupyter notebook.
 
 Further documentation can be found in the [api/client/](api/client) directory and on our [wiki](https://github.com/gro-intelligence/api-client/wiki).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If the API client is installed and your authentication token is set, a csv file 
 2. Try out [soybeans.py](api/client/samples/crop_models/soybeans.py) to see the crop weighted series feature in action:
 
 ```sh
-python crop_modles/soybeans.py
+python crop_models/soybeans.py
 ```
 
 3. See [brazil_soybeans.ipynb](https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/crop_models/brazil_soybeans.ipynb) for a longer, more detailed demonstration of many of the API's capabilities in a Jupyter notebook.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ python crop_models/soybeans.py
 4. You can also use the included `gro_client` tool as a quick way to request a single data series right on the command line. Try the following:
 
 ```sh
-gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@expample.com'
+gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@example.com'
 ```
 
 The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the Python packages.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ If you don't want to enter a password or token each time, you can save the token
 
 Navigate to [api/client/samples/](api/client/samples/) folder and try executing the provided examples.
 
-1. Try [quick_start.py](api/client/samples/quick_start.py).
+1. Start with [quick_start.py](api/client/samples/quick_start.py). This script creates an authenticated `GroClient` object and uses the `get_data_series()` and `get_data_points()` methods to find Area Harvested series for Ukrainian Wheat from a variety of different sources and output the time series points to a CSV file. You will likely want to revisit this script as a starting point for building your own scripts.
+
+Note that the script assumes you have your authentication token set to a `GROAPI_TOKEN` environment variable (see [Saving your token as an environment variable](#saving-your-token-as-an-environment-variable-optional)). If you don't wish to use environment variables, you can modify the sample script to set [`ACCESS_TOKEN`](https://github.com/gro-intelligence/api-client/blob/0d1aa2bccaa25a033e39712c62363fd89e69eea1/api/client/samples/quick_start.py#L7) in some other way.
 
 ```sh
 python quick_start.py
@@ -37,12 +39,20 @@ python quick_start.py
 
 If the API client is installed and your authentication token is set, a csv file called `gro_client_output.csv` should be created in the directory where the script was run.
 
-2. Try out [soybeans.py](api/client/samples/crop_models/soybeans.py) to see the crop weighted series feature in action:
+2. Try out [soybeans.py](api/client/samples/crop_models/soybeans.py) to see the `CropModel` class and its `compute_crop_weighted_series()` method in action. In this example, NDVI ([Normalized difference vegetation index](https://app.gro-intelligence.com/dictionary/items/321)) for provinces in Brazil is weighted against each province's historical soybean production to put the latest NDVI values into context. This information is put into a pandas dataframe, the description of which is printed to the console.
 
 ```sh
 python crop_models/soybeans.py
 ```
 
-3. See [brazil_soybeans.ipynb](https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/crop_models/brazil_soybeans.ipynb) for a longer, more detailed demonstration of many of the API's capabilities in a Jupyter notebook.
+3. See [brazil_soybeans.ipynb](https://github.com/gro-intelligence/api-client/blob/development/api/client/samples/crop_models/brazil_soybeans.ipynb) for a longer, more detailed demonstration of many of the API's capabilities in the form of a Jupyter notebook.
+
+4. You can also use the included `gro_client` tool as a quick way to request a single data series right on the command line. Try the following:
+
+```sh
+gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@expample.com'
+```
+
+The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the Python packages.
 
 Further documentation can be found in the [api/client/](api/client) directory and on our [wiki](https://github.com/gro-intelligence/api-client/wiki).


### PR DESCRIPTION
1. Added a Gro logo to the top of the README
2. Slimmed down the README to cover only the most common cases and remove superfluous or confusing information (`git clone` alternative installation, pip `--target`, `gro_client` example)
3. Updated the authentication token instructions to reference the new Wiki page: https://github.com/gro-intelligence/api-client/wiki/Authentication-Tokens
4. Added `soybeans.py` and `brazil_soybeans.ipynb` examples