### PR TITLE
CLEWS-18068 Allow insert_null as a get_data_points input

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -379,7 +379,7 @@ def get_data_call_params(**selection):
     """
     params = get_params_from_selection(**selection)
     for key, value in list(selection.items()):
-        if key in ('start_date', 'end_date', 'show_revisions'):
+        if key in ('start_date', 'end_date', 'show_revisions', 'insert_null'):
             params[snake_to_camel(key)] = value
     return params
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -368,7 +368,8 @@ def get_data_call_params(**selection):
     selection : dict
         Keys can include: 'metric_id', 'item_id', 'region_id',
         'partner_region_id', 'source_id', 'frequency_id', 'start_date',
-        'end_date', 'show_revisions'. Anything else will be ignored.
+        'end_date', 'show_revisions', and 'insert_null'.
+        Anything else will be ignored.
 
     Returns
     -------


### PR DESCRIPTION
Allow using `insert_null` with `get_data_points()`.

Test script:

```python
import os
from api.client.gro_client import GroClient

API_HOST = 'api.gro-intelligence.com'
ACCESS_TOKEN = os.environ['GROAPI_TOKEN']


def main():
    client = GroClient(API_HOST, ACCESS_TOKEN)
    
    for point in client.get_data_points(
        metric_id=2100031,
        item_id=2165,
        region_id=1000003252,
        source_id=22,
        insert_null=True
    ):
        print(point['start_date'], point['value'])


if __name__ == "__main__":
    main()
```

Returns `None` values where normally they'd be excluded:

```
2018-11-15T00:00:00.000Z 88.2
2018-11-16T00:00:00.000Z 2.8000000000000003
2018-11-17T00:00:00.000Z None
2018-11-18T00:00:00.000Z None
2018-11-19T00:00:00.000Z None
2018-11-20T00:00:00.000Z 0
2018-11-21T00:00:00.000Z 0
2018-11-22T00:00:00.000Z 0
2018-11-23T00:00:00.000Z 3.2
```