### PR TITLE
remove unecessary assert (causes py3 error)

### DIFF
--- a/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
+++ b/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
@@ -850,7 +850,7 @@
    "source": [
     "# corn belt weekly SMOS plot\n",
     "fig, ax_corn = plt.subplots(1, 1, figsize=(20, 15))\n",
-    "corn_belt_weekly_avg = np.average(np.array(corn_belt_weekly), axis=0, weights=county_acreage_3yr_avg.values())\n",
+    "corn_belt_weekly_avg = np.average(np.array(corn_belt_weekly), axis=0, weights=np.array(list(county_acreage_3yr_avg.values())))\n",
     "\n",
     "ax_corn.plot(corn_belt_weekly_avg)\n",
     "ax_corn.set_xlabel(\"week since 2010/01/01\")\n",
@@ -930,7 +930,7 @@
    "source": [
     "# corn belt weekly trmm visualization\n",
     "fig, ax_corn = plt.subplots(1, 1, figsize=(20, 15))\n",
-    "corn_belt_weekly_trmm_avg = np.average(np.array(corn_belt_weekly_trmm), axis=0, weights=county_acreage_3yr_avg.values())\n",
+    "corn_belt_weekly_trmm_avg = np.average(np.array(corn_belt_weekly_trmm), axis=0, weights=np.array(list(county_acreage_3yr_avg.values())))\n",
     "\n",
     "ax_corn.plot(corn_belt_weekly_trmm_avg)\n",
     "ax_corn.set_xlabel(\"week since 2000/03/06\")\n",

--- a/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
+++ b/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
@@ -755,8 +755,6 @@
     "        county_acreage_3yr_avg_list.append(0.0)\n",
     "        continue\n",
     "        \n",
-    "    # THIS IS IN HECTARES:\n",
-    "    assert county_acreage_data.values()[0][0][\"unit_id\"] == 42\n",
     "    \n",
     "    county_acreage_3yr_avg[county_id] = np.mean([point[\"value\"] for point in county_dataseries[-3:]])*2.47105\n",
     "    county_acreage_3yr_avg_list.append(np.mean([point[\"value\"] for point in county_dataseries[-3:]])*2.47105)\n",

--- a/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
+++ b/api/client/samples/prevented_plant/prevented_plant_xgboost.ipynb
@@ -1481,7 +1481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.loc[:, 'year'] = range(2011, 2019)*918"
+    "df.loc[:, 'year'] = list(range(2011, 2019))*918"
    ]
   },
   {


### PR DESCRIPTION
dict_values is no longer subscriptable in py3 so this assert fails. however we don't need it anymore.