### PR TITLE
CLEWS-19599 Client-side Unit Conversion

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -6,8 +6,6 @@ class Client(object):
 
     """API client with stateful authentication for lib functions. """
 
-    __unit_names = {}
-
     def __init__(self, api_host, access_token):
         self.api_host = api_host
         self.access_token = access_token
@@ -22,10 +20,7 @@ class Client(object):
         return lib.lookup(self.access_token, self.api_host, entity_type, entity_id)
 
     def lookup_unit_abbreviation(self, unit_id):
-        """Wrapper to lookup unit names, with local cache to avoid repeated lookups."""
-        if unit_id not in self.__unit_names:
-            self.__unit_names[unit_id] = self.lookup('units', unit_id)['abbreviation']
-        return self.__unit_names[unit_id]
+        return self.lookup('units', unit_id)['abbreviation']
 
     def get_data_series(self, **selection):
         return lib.get_data_series(self.access_token, self.api_host, **selection)
@@ -58,6 +53,3 @@ class Client(object):
     def get_descendant_regions(self, region_id, descendant_level=None):
         return lib.get_descendant_regions(self.access_token, self.api_host,
                                           region_id, descendant_level)
-
-    def convert_unit(self, value, from_unit_id, to_unit_id):
-        return lib.convert_unit(self.access_token, self.api_host, value, from_unit_id, to_unit_id)

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -76,8 +76,7 @@ class GroClient(Client):
                 tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
             if self._data_frame is None:
                 self._data_frame = tmp
-                self._data_frame.set_index(
-                    [col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
+                self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
             else:
                 self._data_frame = self._data_frame.merge(tmp, how='outer')
         return self._data_frame
@@ -154,17 +153,14 @@ class GroClient(Client):
         """
         results = self.search(entity_type, keywords)
         for result in results:
-            self._logger.debug("First result, out of {} {}: {}".format(
-                len(results), entity_type, result['id']))
+            self._logger.debug("First result, out of {} {}: {}".format(len(results), entity_type, result['id']))
             return result['id']
 
     def get_provinces(self, country_name):
         for region in self.search_and_lookup('regions', country_name):
-            if region['level'] == 3:  # country
-                provinces = self.get_descendant_regions(
-                    region['id'], 4)  # provinces
-                self._logger.debug(
-                    "Provinces of {}: {}".format(country_name, provinces))
+            if region['level'] == lib.REGION_LEVELS['country']:
+                provinces = self.get_descendant_regions(region['id'], lib.REGION_LEVELS['province'])
+                self._logger.debug("Provinces of {}: {}".format(country_name, provinces))
                 return provinces
         return None
 
@@ -184,8 +180,7 @@ class GroClient(Client):
             entity_list = self.list_available(selected_entities)
             num = len(entity_list)
         entities = entity_list[int(num*random())]
-        self._logger.info(
-            "Using randomly selected entities: {}".format(str(entities)))
+        self._logger.info("Using randomly selected entities: {}".format(str(entities)))
         selected_entities.update(entities)
         return selected_entities
 
@@ -197,8 +192,7 @@ class GroClient(Client):
         if not data_series_list:
             raise Exception("No data series available for {}".format(
                 selected_entities))
-        selected_data_series = data_series_list[int(
-            len(data_series_list)*random())]
+        selected_data_series = data_series_list[int(len(data_series_list)*random())]
         return selected_data_series
 
     # TODO: rename function to "write_..." rather than "print_..."
@@ -237,7 +231,8 @@ class GroClient(Client):
             'units', point['unit_id']).get('baseConvFactor')
         if not from_convert_factor.get('factor'):
             raise Exception(
-                'unit_id {} is not convertible'.format(point['unit_id']))
+                'unit_id {} is not convertible'.format(point['unit_id'])
+            )
         value_in_base_unit = point['value'] * \
             from_convert_factor.get('factor') + \
             from_convert_factor.get('offset', 0)
@@ -245,7 +240,8 @@ class GroClient(Client):
             'units', target_unit_id).get('baseConvFactor')
         if not to_convert_factor.get('factor'):
             raise Exception(
-                'unit_id {} is not convertible'.format(target_unit_id))
+                'unit_id {} is not convertible'.format(target_unit_id)
+            )
         point['value'] = (
             value_in_base_unit - to_convert_factor.get('offset', 0)
         ) / to_convert_factor.get('factor')
@@ -276,8 +272,7 @@ def main():
     else:
         if not args.user_password:
             args.user_password = getpass.getpass()
-        access_token = lib.get_access_token(
-            API_HOST, args.user_email, args.user_password)
+        access_token = lib.get_access_token(API_HOST, args.user_email, args.user_password)
     if args.print_token:
         print(access_token)
         sys.exit(0)
@@ -285,17 +280,13 @@ def main():
 
     selected_entities = {}
     if args.item:
-        selected_entities['item_id'] = client.search_for_entity(
-            'items', args.item)
+        selected_entities['item_id'] = client.search_for_entity('items', args.item)
     if args.metric:
-        selected_entities['metric_id'] = client.search_for_entity(
-            'metrics', args.metric)
+        selected_entities['metric_id'] = client.search_for_entity('metrics', args.metric)
     if args.region:
-        selected_entities['region_id'] = client.search_for_entity(
-            'regions', args.region)
+        selected_entities['region_id'] = client.search_for_entity('regions', args.region)
     if args.partner_region:
-        selected_entities['partner_region_id'] = client.search_for_entity(
-            'regions', args.partner_region)
+        selected_entities['partner_region_id'] = client.search_for_entity('regions', args.partner_region)
     if not selected_entities:
         selected_entities = client.pick_random_entities()
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -18,6 +18,7 @@ from random import random
 import argparse
 import getpass
 import itertools
+import functools
 import math
 import os
 import pandas
@@ -75,10 +76,34 @@ class GroClient(Client):
                 tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
             if self._data_frame is None:
                 self._data_frame = tmp
-                self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
+                self._data_frame.set_index(
+                    [col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
             else:
                 self._data_frame = self._data_frame.merge(tmp, how='outer')
         return self._data_frame
+
+    def get_data_points(self, **selections):
+        """Extend the Client's get_data_points method to add unit conversion.
+
+        Parameters
+        ----------
+        selections : dict
+            See lib.py get_data_points() for the base list of inputs
+            This extended version may additionally include 'unit_id' which is
+            the unit you wish to convert all points to.
+
+        Returns
+        -------
+        list of dicts
+            Unchanged output format from lib.py get_data_points()
+
+        """
+        data_points = super(GroClient, self).get_data_points(**selections)
+        # Apply unit conversion if a unit is specified
+        if 'unit_id' in selections:
+            return map(functools.partial(self.convert_unit, target_unit_id=selections['unit_id']), data_points)
+        # Return data points in input units if not unit is specified
+        return data_points
 
     def get_data_series_list(self):
         return list(self._data_series_list)
@@ -135,9 +160,11 @@ class GroClient(Client):
 
     def get_provinces(self, country_name):
         for region in self.search_and_lookup('regions', country_name):
-            if region['level'] == 3: # country
-                provinces =  self.get_descendant_regions(region['id'], 4) # provinces
-                self._logger.debug("Provinces of {}: {}".format(country_name, provinces))
+            if region['level'] == 3:  # country
+                provinces = self.get_descendant_regions(
+                    region['id'], 4)  # provinces
+                self._logger.debug(
+                    "Provinces of {}: {}".format(country_name, provinces))
                 return provinces
         return None
 
@@ -157,7 +184,8 @@ class GroClient(Client):
             entity_list = self.list_available(selected_entities)
             num = len(entity_list)
         entities = entity_list[int(num*random())]
-        self._logger.info("Using randomly selected entities: {}".format(str(entities)))
+        self._logger.info(
+            "Using randomly selected entities: {}".format(str(entities)))
         selected_entities.update(entities)
         return selected_entities
 
@@ -169,7 +197,8 @@ class GroClient(Client):
         if not data_series_list:
             raise Exception("No data series available for {}".format(
                 selected_entities))
-        selected_data_series = data_series_list[int(len(data_series_list)*random())]
+        selected_data_series = data_series_list[int(
+            len(data_series_list)*random())]
         return selected_data_series
 
     # TODO: rename function to "write_..." rather than "print_..."
@@ -182,6 +211,46 @@ class GroClient(Client):
             writer.writerow([point['start_date'], point['end_date'],
                              point['value'] * point['input_unit_scale'],
                              self.lookup_unit_abbreviation(point['input_unit_id'])])
+
+    def convert_unit(self, point, target_unit_id):
+        """Convert the data point from one unit to another unit.
+
+        If original or target unit is non-convertible, throw an error.
+
+        Parameters
+        ----------
+        point : dict
+            { value: float, unit_id: integer, ... }
+        to_unit_id : integer
+
+        Returns
+        -------
+        dict
+            { value: float, unit_id: integer, ... }
+            unit_id is changed to the target, and value is converted to use the
+            new unit_id. Other properties are unchanged.
+
+        """
+        if point['unit_id'] == target_unit_id:
+            return point
+        from_convert_factor = self.lookup(
+            'units', point['unit_id']).get('baseConvFactor')
+        if not from_convert_factor.get('factor'):
+            raise Exception(
+                'unit_id {} is not convertible'.format(point['unit_id']))
+        value_in_base_unit = point['value'] * \
+            from_convert_factor.get('factor') + \
+            from_convert_factor.get('offset', 0)
+        to_convert_factor = self.lookup(
+            'units', target_unit_id).get('baseConvFactor')
+        if not to_convert_factor.get('factor'):
+            raise Exception(
+                'unit_id {} is not convertible'.format(target_unit_id))
+        point['value'] = (
+            value_in_base_unit - to_convert_factor.get('offset', 0)
+        ) / to_convert_factor.get('factor')
+        point['unit_id'] = target_unit_id
+        return point
 
 
 def main():
@@ -207,7 +276,8 @@ def main():
     else:
         if not args.user_password:
             args.user_password = getpass.getpass()
-        access_token = lib.get_access_token(API_HOST, args.user_email, args.user_password)
+        access_token = lib.get_access_token(
+            API_HOST, args.user_email, args.user_password)
     if args.print_token:
         print(access_token)
         sys.exit(0)
@@ -215,13 +285,17 @@ def main():
 
     selected_entities = {}
     if args.item:
-        selected_entities['item_id'] = client.search_for_entity('items', args.item)
+        selected_entities['item_id'] = client.search_for_entity(
+            'items', args.item)
     if args.metric:
-        selected_entities['metric_id'] = client.search_for_entity('metrics', args.metric)
+        selected_entities['metric_id'] = client.search_for_entity(
+            'metrics', args.metric)
     if args.region:
-        selected_entities['region_id'] = client.search_for_entity('regions', args.region)
+        selected_entities['region_id'] = client.search_for_entity(
+            'regions', args.region)
     if args.partner_region:
-        selected_entities['partner_region_id'] = client.search_for_entity('regions', args.partner_region)
+        selected_entities['partner_region_id'] = client.search_for_entity(
+            'regions', args.partner_region)
     if not selected_entities:
         selected_entities = client.pick_random_entities()
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -153,7 +153,8 @@ class GroClient(Client):
         """
         results = self.search(entity_type, keywords)
         for result in results:
-            self._logger.debug("First result, out of {} {}: {}".format(len(results), entity_type, result['id']))
+            self._logger.debug("First result, out of {} {}: {}".format(
+                len(results), entity_type, result['id']))
             return result['id']
 
     def get_provinces(self, country_name):

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -245,7 +245,7 @@ class GroClient(Client):
             raise Exception(
                 'unit_id {} is not convertible'.format(target_unit_id)
             )
-        point['value'] = (
+        point['value'] = float(
             value_in_base_unit - to_convert_factor.get('offset', 0)
         ) / to_convert_factor.get('factor')
         point['unit_id'] = target_unit_id

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -216,7 +216,7 @@ class GroClient(Client):
         ----------
         point : dict
             { value: float, unit_id: integer, ... }
-        to_unit_id : integer
+        target_unit_id : integer
 
         Returns
         -------
@@ -229,16 +229,18 @@ class GroClient(Client):
         if point['unit_id'] == target_unit_id:
             return point
         from_convert_factor = self.lookup(
-            'units', point['unit_id']).get('baseConvFactor')
+            'units', point['unit_id']
+        ).get('baseConvFactor')
         if not from_convert_factor.get('factor'):
             raise Exception(
                 'unit_id {} is not convertible'.format(point['unit_id'])
             )
-        value_in_base_unit = point['value'] * \
-            from_convert_factor.get('factor') + \
-            from_convert_factor.get('offset', 0)
+        value_in_base_unit = (
+            point['value'] * from_convert_factor.get('factor')
+         ) + from_convert_factor.get('offset', 0)
         to_convert_factor = self.lookup(
-            'units', target_unit_id).get('baseConvFactor')
+            'units', target_unit_id
+        ).get('baseConvFactor')
         if not to_convert_factor.get('factor'):
             raise Exception(
                 'unit_id {} is not convertible'.format(target_unit_id)

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -1,0 +1,81 @@
+try:
+    # Python 3.3+
+    from unittest.mock import MagicMock
+except ImportError:
+    # Python 2.7
+    from mock import MagicMock
+
+import pytest
+from api.client.gro_client import GroClient
+
+MOCK_HOST = 'pytest.groclient.url'
+MOCK_TOKEN = 'pytest.groclient.token'
+
+client = GroClient(MOCK_HOST, MOCK_TOKEN)
+
+
+def mock_test_units(entity_type, entity_id):
+    if entity_type=='units' and entity_id==10:
+        return {
+            'id': 10,
+            'name': 'kilogram',
+            'baseConvFactor': { 'factor': 1 },
+            'convType': 0
+        }
+    elif entity_type=='units' and entity_id==14:
+        return {
+            'id': 14,
+            'name': 'tonne',
+            'baseConvFactor': { 'factor': 1000 },
+            'convType': 0
+        }
+    elif entity_type=='units' and entity_id==36:
+        return {
+            'id': 36,
+            'name': 'Celsius',
+            'baseConvFactor': { 'factor': 1, 'offset': 273 },
+            'convType': 1
+        }
+    elif entity_type=='units' and entity_id==37:
+        return {
+            'id': 37,
+            'name': 'Fahrenheit',
+            'baseConvFactor': {
+                'factor': 0.5,
+                'offset': 255
+            },
+            'convType': 1
+        }
+    elif entity_type=='units' and entity_id==43:
+        return {
+            'id': 43,
+            'name': 'US Dollar (constant 2010)',
+            'baseConvFactor': { 'factor': None },
+            'convType': 0
+        }
+    else:
+        raise '{} {} not mocked'.format(entity_type, entity_id)
+
+client.lookup = MagicMock(
+    side_effect=mock_test_units
+)
+
+def test_convert_unit():
+    assert client.convert_unit({ 'value': 1, 'unit_id': 10 }, 10) == {
+        'value': 1,
+        'unit_id': 10
+    }
+    assert client.convert_unit({ 'value': 1, 'unit_id': 10 }, 14) == {
+        'value': 0.001,
+        'unit_id': 14
+    }
+    assert client.convert_unit({ 'value': 3, 'unit_id': 36 }, 37) == {
+        'value': 42,
+        'unit_id': 37
+    }
+    assert client.convert_unit({ 'value': 1, 'unit_id': 37 }, 36) == {
+        'value': -17.5,
+        'unit_id': 36
+    }
+    with pytest.raises(Exception):
+        assert client.convert_unit({ 'value': 1, 'unit_id': 10 }, 43)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -12,7 +12,11 @@ import json
 import logging
 import requests
 import time
-from functools import lru_cache as memoize
+try:
+    # functools are native in Python 3.2.3+
+    from functools import lru_cache as memoize
+except ImportError:
+    from backports.functools_lru_cache import lru_cache as memoize
 
 CROP_CALENDAR_METRIC_ID = 2260063
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.functools_lru_cache
 certifi
 chardet
 future

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/gro-intelligence/api-client",
     packages=setuptools.find_packages(),
-    python_requires=">=2.7.6",
+    python_requires=">=2.7.6, !=3.0.*, !=3.1.*, !=3.2.*, <4",
     install_requires=requirements,
     setup_requires=pytest_runner,
     test_suite='pytest',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("test-requirements.txt", "r") as test_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.19.1",
+    version="1.19.2",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
Changes from add_unit_conversion branch:

1. Removed the `convert_unit` function from lib and Client and placed it instead in `GroClient`.
2. `convert_unit` takes a point and a target unit, rather than a value, a from_unit, and a to_unit. A modified `point` dict is returned instead of a single value.
3. If the original unit and the target unit are identical, exit early
4. Extended the GroClient's `get_data_points()` function to first call the `Client` version and then apply unit conversion automatically if a target unit is provided.
5. Added memoization to lib functions where applicable. This eliminates the multiple redundant lookups of unit conversion factors when looping through a long list of get_data_points responses

Tested with the following script:

```py
import os
from api.client.gro_client import GroClient

API_HOST = 'api.gro-intelligence.com'
ACCESS_TOKEN = os.environ['GROAPI_TOKEN']

def main():
    client = GroClient(API_HOST, ACCESS_TOKEN)

    YIELD=170037
    CORN=274
    UNITED_STATES=1215
    GRO_YM=32
    ANNUAL=9
    TONNES_PER_HECTARE=61
    BUSHELS_PER_ACRE=284

    print('No conversion')
    for point in client.get_data_points(
        metric_id=YIELD,
        item_id=CORN,
        region_id=UNITED_STATES,
        source_id=GRO_YM,
        frequency_id=ANNUAL,
        unit_id=TONNES_PER_HECTARE
    ):
        print(point['value'], client.lookup_unit_abbreviation(point['unit_id']))

    print('Convert into identical unit')
    for point in client.get_data_points(
        metric_id=YIELD,
        item_id=CORN,
        region_id=UNITED_STATES,
        source_id=GRO_YM,
        frequency_id=ANNUAL,
        unit_id=TONNES_PER_HECTARE
    ):
        print(point['value'], client.lookup_unit_abbreviation(point['unit_id']))

    print('Convert into different unit')
    for point in client.get_data_points(
        metric_id=YIELD,
        item_id=CORN,
        region_id=UNITED_STATES,
        source_id=GRO_YM,
        frequency_id=ANNUAL,
        unit_id=BUSHELS_PER_ACRE
    ):
        print(point['value'], client.lookup_unit_abbreviation(point['unit_id']))

    print('Convert units when there\'s no data:', list(client.get_data_points(
        metric_id=YIELD,
        item_id=CORN,
        region_id=UNITED_STATES,
        source_id=GRO_YM,
        frequency_id=ANNUAL,
        start_date='2020-01-01',
        unit_id=BUSHELS_PER_ACRE
    )))

if __name__ == "__main__":
    main()
```

Output:

```
$ python CLEWS-19599.py 
No conversion
10.825978048472363 t/ha
10.957399391107465 t/ha
11.179951735272198 t/ha
10.053230574702063 t/ha
Convert into identical unit
10.825978048472363 t/ha
10.957399391107465 t/ha
11.179951735272198 t/ha
10.053230574702063 t/ha
Convert into different unit
172.475851555 bu/acre
174.569612311026 bu/acre
178.115241620776 bu/acre
160.164697959569 bu/acre
Convert units when there's no data: []
```