### PR TITLE
Pass unit conversion map on empty data point

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -226,7 +226,7 @@ class GroClient(Client):
             new unit_id. Other properties are unchanged.
 
         """
-        if point['unit_id'] == target_unit_id:
+        if point.get('unit_id') is None or point.get('unit_id') == target_unit_id:
             return point
         from_convert_factor = self.lookup(
             'units', point['unit_id']

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -100,7 +100,7 @@ class GroClient(Client):
         data_points = super(GroClient, self).get_data_points(**selections)
         # Apply unit conversion if a unit is specified
         if 'unit_id' in selections:
-            return map(functools.partial(self.convert_unit, target_unit_id=selections['unit_id']), data_points)
+            return list(map(functools.partial(self.convert_unit, target_unit_id=selections['unit_id']), data_points))
         # Return data points in input units if not unit is specified
         return data_points
 

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -77,5 +77,8 @@ def test_convert_unit():
         'value': -17.5,
         'unit_id': 36
     }
+
+    assert client.convert_unit({}, 36) == {}
+
     with pytest.raises(Exception):
         assert client.convert_unit({ 'value': 1, 'unit_id': 10 }, 43)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("test-requirements.txt", "r") as test_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.19.2",
+    version="1.19.3",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
Tested locally using the script

```
import os
from api.client.gro_client import GroClient

API_HOST = 'api.gro-intelligence.com'
ACCESS_TOKEN = os.environ['GROAPI_TOKEN']

client = GroClient(API_HOST, ACCESS_TOKEN)

state_ids = {
    u'Arkansas': 13054,
    u'Illinois': 13064,
    u'Indiana': 13065,
    u'Iowa': 13066,
    u'Kansas': 13067,
    u'Kentucky': 13068,
    u'Louisiana': 13069,
    u'Michigan': 13073,
    u'Minnesota': 13074,
    u'Mississippi': 13075,
    u'Missouri': 13076,
    u'Nebraska': 13078,
    u'North Carolina': 13084,
    u'North Dakota': 13085,
    u'Ohio': 13086,
    u'South Dakota': 13092,
    u'Tennessee': 13093,
    u'Wisconsin': 13100
}

county_ids = {
    state_id: [county["id"] for county in client.get_descendant_regions(state_id, 5)]
    for state_id in state_ids.values()
}

print(county_ids)

for state_id in state_ids.values():
    for county_id in county_ids[state_id]:
        print(client.get_data_points(**{
            'metric_id': 2580001, # planted area
            'item_id': 270, # corn or soy
            'region_id': county_id,
            'source_id': 25, # nass
            'frequency_id': 9, # yearly
            # 'unit_id': 41, # acre
        }))
        print(client.get_data_points(**{
            'metric_id': 2580001, # planted area
            'item_id': 270, # corn or soy
            'region_id': county_id,
            'source_id': 25, # nass	
            'frequency_id': 9, # yearly
            'unit_id': 41, # acre
        }))
        os.system('clear') # for unix users
```

Before this PR, it fails on one `get_data_points()` output which is `[{}]`. After this PR it works.