### PR TITLE
CLEWS-16545 Add Anaconda notes to installation instructions and update client descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python crop_models/soybeans.py
 4. You can also use the included `gro_client` tool as a quick way to request a single data series right on the command line. Try the following:
 
 ```sh
-gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@example.com'
+gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --user_email="email@example.com"
 ```
 
 The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ Client library for accessing Gro Intelligence's agricultural data platform.
 pip install git+https://github.com/gro-intelligence/api-client.git
 ```
 
+Note that even if you are using [Anaconda](https://www.anaconda.com/), the API Client install should still be performed using pip and not [conda](https://docs.conda.io/en/latest/).
+
 ## Gro API authentication token
 
 Use the Gro web application to retrieve an authentication token (instructions are in the wiki [here](https://github.com/gro-intelligence/api-client/wiki/Authentication-Tokens#11-using-the-gro-web-application-preferred)).
 
 ### Saving your token as an environment variable (optional)
 
-If you don't want to enter a password or token each time, you can save the token as an environment variable. Please consult your OS or IDE documentation for information on how to set environment variables, e.g. [setting environment variables in Windows Powershell](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-6) and [Mac OS X/Linux](https://apple.stackexchange.com/questions/106778/how-do-i-set-environment-variables-on-os-x). In some of the sample code, it is assumed that you have the token saved to your environment variables as `GROAPI_TOKEN`.
+If you don't want to enter a password or token each time, you can save the token as an environment variable. Please consult your OS or IDE documentation for information on how to set environment variables, e.g. [setting environment variables in Windows Powershell](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-6) or [Mac OS X/Linux](https://apple.stackexchange.com/questions/106778/how-do-i-set-environment-variables-on-os-x) or [Anaconda environmnent variables](https://anaconda-project.readthedocs.io/en/latest/user-guide/tasks/work-with-variables.html). In some of the sample code, it is assumed that you have the token saved to your environment variables as `GROAPI_TOKEN`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Gro API Client
 
-https://www.gro-intelligence.com/products/gro-api
+<https://www.gro-intelligence.com/products/gro-api>
 
 Client library for accessing Gro Intelligence's agricultural data platform.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ python crop_models/soybeans.py
 gro_client --metric='Production Quantity mass' --item='Corn' --region='United States' --user_email='email@example.com'
 ```
 
-The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the Python packages.
+The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.
 
 Further documentation can be found in the [api/client/](api/client) directory and on our [wiki](https://github.com/gro-intelligence/api-client/wiki).

--- a/api/client/README.md
+++ b/api/client/README.md
@@ -1,6 +1,6 @@
-# Public Gro api client library and examples
+# Gro API Library and Client Classes
 
-* [lib.py](lib.py) is a helper library for clients accessing the Gro API
-* The [Client class](__init__.py) provides those library functions with stateful authentication
-* [gro_client.py](gro_client.py) is an example client, which shows various ways of finding and outputing data series.
-* The [/samples](/api/client/samples) directory contains several example scripts using the client library
+* The [lib module](lib.py) contains all of the base functions for accessing the Gro API.
+* The [Client class](__init__.py) provides those library functions with stateful authentication.
+* The [GroClient class](gro_client.py) extends the Client class and adds extra utility functions. This is the recommended class for most users.
+* The [samples/](samples/) directory contains example scripts and models using the Gro API that you can run for yourself.

--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -4,7 +4,7 @@ from api.client import lib
 
 class Client(object):
 
-    """API client with stateful authentication for lib functions. """
+    """API client with stateful authentication for lib functions."""
 
     def __init__(self, api_host, access_token):
         self.api_host = api_host

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -1,16 +1,3 @@
-"""
-Basic gro api client.
-
-Usage examples:
-
-python gro_client.py --item=soybeans  --region=brazil --partner_region china --metric export
-python gro_client.py --item=sesame --region=ethiopia
-
-python gro_client.py --user_email=john.doe@example.com  --print_token
-
-For more information use --help
-"""
-
 from __future__ import print_function
 from builtins import zip
 from builtins import str
@@ -37,14 +24,13 @@ DATA_POINTS_UNIQUE_COLS = ['item_id', 'metric_id',
 
 
 class GroClient(Client):
-    """A Client with methods to find, and manipulate data series related
-    to a crop and/or region.
+    """An extension of the Client class with extra convenience methods for some common operations.
 
-    This class offers convenience methods for some common scenarios
-
-    - finding entities by name rather than ids
-    - exploration shortcuts filling in partial selections
-    - finding and saving data series for repeated use, including in a data frame
+    Extra functionality includes:
+    - Automatic conversion of units
+    - Finding data series using entity names rather than ids
+    - Exploration shortcuts for filling in partial selections
+    - Saving data series in a data frame for repeated use
 
     """
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -238,8 +238,18 @@ class GroClient(Client):
         return point
 
 
+"""Basic Gro API command line interface.
+
+Note that results are chosen randomly from matching selections, and so results are not deterministic. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.
+
+Usage examples:
+    gro_client --item=soybeans  --region=brazil --partner_region china --metric export
+    gro_client --item=sesame --region=ethiopia
+    gro_client --user_email=john.doe@example.com  --print_token
+For more information use --help
+"""
 def main():
-    parser = argparse.ArgumentParser(description="Gro api client")
+    parser = argparse.ArgumentParser(description="Gro API command line interface")
     parser.add_argument("--user_email")
     parser.add_argument("--user_password")
     parser.add_argument("--item")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/gro-intelligence/api-client",
     packages=setuptools.find_packages(),
-    python_requires=">=2.7.6, !=3.0.*, !=3.1.*, !=3.2.*, <4",
+    python_requires=">=2.7.13, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     install_requires=requirements,
     setup_requires=pytest_runner,
     test_suite='pytest',

--- a/unix-setup.md
+++ b/unix-setup.md
@@ -1,6 +1,4 @@
 # MacOS and Linux Prerequisites
 
 1. git ([Installation instructions](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git))
-2. python (2.7.x or 3.x) ([2 Installation instructions](https://docs.python.org/2/using/index.html) / [3 Installation instructions](https://docs.python.org/3/using/index.html))
-3. pip ([Installation instructions](https://pip.pypa.io/en/stable/installing/). Note "pip is already installed if you are using Python 2 >=2.7.9 or Python 3 >=3.4")
-
+2. Download Python version 3.5 or above from [python.org](https://www.python.org/downloads/). Support for Python 2.7.13 or above is also maintained, but with [its End of Life](https://mail.python.org/pipermail/python-dev/2018-March/152348.html) soon approaching, it is recommended you start with Python 3.

--- a/windows-setup.md
+++ b/windows-setup.md
@@ -1,7 +1,14 @@
 # Windows Prerequisites
 
-1. [Powershell](https://docs.microsoft.com/en-us/powershell/)
-2. Download Python version >= 2.7.13 from [python.org](https://www.python.org/downloads/windows/).
-3. Install both Python and pip to PATH either in installer (enable component during the installation) or manually. The easiest way to do this is to make sure the below is checked during installation: ![readme_add_python_to_path_installer](readme_add_python_to_path_installer.png)
-4. Install Git from [git-scm.com](https://git-scm.com/download/win). Proceed with the default options.
+The Gro API Client package is supported both with or without Anaconda. However, some popular data science packages, including some used in the sample scripts provided, are only available on Windows via [conda](https://docs.conda.io/en/latest/). For that reason, instructions are provided for both. You should select the distribution that fits your requirements.
 
+## Anaconda
+
+1. Download Anaconda with Python 3.5 or above from [anaconda.com](https://www.anaconda.com/distribution/). Support for Python 2.7.13 or above is also maintained, but with [its End of Life](https://mail.python.org/pipermail/python-dev/2018-March/152348.html) soon approaching, it is recommended you start with Python 3.
+2. Install Git from [git-scm.com](https://git-scm.com/download/win). Proceed with the default options.
+
+## Non-Anaconda
+
+1. Download Python version 3.5 or above from [python.org](https://www.python.org/downloads/windows/). Support for Python 2.7.13 or above is also maintained, but with [its End of Life](https://mail.python.org/pipermail/python-dev/2018-March/152348.html) soon approaching, it is recommended you start with Python 3.
+2. Install both Python and pip to PATH either in the installer (enable component during the installation) or manually. The easiest way to do this is to make sure the below is checked during installation: ![readme_add_python_to_path_installer](readme_add_python_to_path_installer.png)
+3. Install Git from [git-scm.com](https://git-scm.com/download/win). Proceed with the default options.


### PR DESCRIPTION
This PR hopes to clarify two main things:

1. Installation for Windows, in both regular and Anaconda Python distributions, informed by the work done recently Prevent Plant installation instruction updates https://github.com/gro-intelligence/api-client/tree/development/api/client/samples/prevented_plant#for-windows and what versions are required/recommended.
2. Encouraging use of the GroClient class, removing words "example" and "basic" that referred to the command line interface rather than the class. Clarified the distinction between the two.