### PR TITLE
CLEWS-19994 Allow Python 2.7.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/gro-intelligence/api-client",
     packages=setuptools.find_packages(),
-    python_requires=">=2.7.13, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    python_requires=">=2.7.12, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     install_requires=requirements,
     setup_requires=pytest_runner,
     test_suite='pytest',


### PR DESCRIPTION
In https://github.com/gro-intelligence/api-client/pull/94 the setup.py python_requires version was brought up to match the versions noted in the documentation. 2.7.12 is known to still work on Mac/Linux, but hasn't been tested in Windows.

Documentation will still state 2.7.13 or above, but version enforcement during installation will be more permissive for legacy support.