### PR TITLE
Don't retry 401/404/500

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -162,6 +162,8 @@ def get_data(url, headers, params=None, logger=None):
             time.sleep(2 ** retry_count)  # Exponential backoff before retrying
         elif data.status_code == 301:
             params = redirect(params, data.json()['data'][0])
+        elif data.status_code in [404, 401, 500]: 
+            break;
         else:
             logger.error(data.text, extra=log_record)
     raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(
@@ -788,9 +790,9 @@ def get_geojson(access_token, api_host, region_id):
 
     Returns
     -------
-    a geojson object e.g. 
+    a geojson object e.g.
     { 'type': 'GeometryCollection',
-      'geometries': [{'type': 'MultiPolygon', 
+      'geometries': [{'type': 'MultiPolygon',
                       'coordinates': [[[[-38.394, -4.225], ...]]]}, ...]}
     or None if not found.
     """

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -162,8 +162,8 @@ def get_data(url, headers, params=None, logger=None):
             time.sleep(2 ** retry_count)  # Exponential backoff before retrying
         elif data.status_code == 301:
             params = redirect(params, data.json()['data'][0])
-        elif data.status_code in [404, 401, 500]: 
-            break;
+        elif data.status_code in [404, 401, 500]:
+            break
         else:
             logger.error(data.text, extra=log_record)
     raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(


### PR DESCRIPTION
Small change in the get_data retry loop to break if the error code indicates not found, unauthorized, or server error. This prevents retrying in obvious cases where the token is invalid or the URL is wrong but also should prevent retrying in the case reported in the issue where rank_series_by_source was returning a 404.

```
lib.get_data('http://api.gro-intelligence.com/v2/available/sources', '')
->
{"statusCode":401,"error":"Unauthorized","message":"Missing authentication"}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "api/client/lib.py", line 170, in get_data
    url, retry_count, data.text))
Exception: Giving up on http://api.gro-intelligence.com/v2/available/sources after 1 tries. Error is: {"statusCode":401,"error":"Unauthorized","message":"Missing authentication"}.
```

```
lib.get_data('http://api.gro-intelligence.com/asdfjhlkj', '')
->
{"statusCode":404,"error":"Not Found"}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "api/client/lib.py", line 170, in get_data
    url, retry_count, data.text))
Exception: Giving up on http://api.gro-intelligence.com/asdfjhlkj after 1 tries. Error is: {"statusCode":404,"error":"Not Found"}.
```