### PR TITLE
update metric_id for availability of soil water capacity from soilgrids

### DIFF
--- a/api/client/samples/similar_regions/region_properties.py
+++ b/api/client/samples/similar_regions/region_properties.py
@@ -126,7 +126,7 @@ region_properties = {
     },
     "soil_water_capacity_100cm": {
         "selected_entities": {
-            'metric_id': 15531050,
+            'metric_id': 15531082,
             'item_id': 9194,
             'source_id': 89,
             'frequency_id': 15


### PR DESCRIPTION
metric id has been updated for soil water capacity from soilgrids
`# Soil water capacity until wilting point at 100 cm deep - Availability in soil (volume/volume) - World (SoilGrids)
client.get_data_points(**{
	'metric_id': 15531082, 
	'item_id': 9194, 
	'region_id': 0, 
	'source_id': 89, 
	'frequency_id': 15
})`