### PR TITLE
CLEWS-22156 Add redirect following to BatchClient

### DIFF
--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -67,7 +67,13 @@ class BatchClient(Client):
                     if e.code in [429, 503, 504]:
                         time.sleep(2 ** retry_count)  # Exponential backoff
                     elif e.code == 301:
-                        params = lib.redirect(params, json.loads(e.response.body.decode("utf-8"))['data'][0])
+                        new_params = lib.redirect(
+                            params,
+                            json.loads(e.response.body.decode("utf-8"))['data'][0])
+                        self._logger.warning(
+                            'Redirecting {} to {}'.format(params, new_params),
+                            extra=log_record)
+                        params = new_params
                 else:
                     self._logger.error(e.response.error, extra=log_record)
                     raise Exception('Giving up on {} after {} tries. \
@@ -100,7 +106,7 @@ class BatchClient(Client):
         :param output_list:
         :param map_result:
         :return:
-        
+
         """
         assert type(batched_args) is list, \
             "Only argument to a batch async decorated function should be a \

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -39,13 +39,11 @@ class BatchClient(Client):
         self._logger.debug(url)
         while retry_count < cfg.MAX_RETRIES:
             start_time = time.time()
-            http_request = HTTPRequest(
-                '{url}?{params}'.format(url=url, params=urlencode(params)),
-                method="GET",
-                headers=headers,
-                request_timeout=cfg.TIMEOUT,
-                connect_timeout=cfg.TIMEOUT
-            )
+            http_request = HTTPRequest('{url}?{params}'.format(url=url, params=urlencode(params)),
+                                       method="GET",
+                                       headers=headers,
+                                       request_timeout=cfg.TIMEOUT,
+                                       connect_timeout=cfg.TIMEOUT)
             try:
                 data = yield self._http_client.fetch(http_request)
                 elapsed_time = time.time() - start_time

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -90,7 +90,7 @@ def get_access_token(api_host, user_email, user_password, logger=None):
         retry_count))
 
 
-def redirect(params, migration):
+def redirect(old_params, migration):
     """Update query parameters to follow a redirection response from the API.
 
     >>> redirect(
@@ -101,7 +101,7 @@ def redirect(params, migration):
 
     Parameters
     ----------
-    params : dict
+    old_params : dict
         The original parameters provided to the API request
     migration : dict
         The body of the 301 response indicating which of the inputs have been
@@ -109,17 +109,18 @@ def redirect(params, migration):
 
     Returns
     -------
-    params : dict
+    new_params : dict
         The mutated params object with values replaced according to the
         redirection instructions provided by the API
 
     """
+    new_params = old_params.copy()
     for migration_key in migration:
         split_mig_key = migration_key.split('_')
         if split_mig_key[0] == 'new':
             param_key = snake_to_camel('_'.join([split_mig_key[1], 'id']))
-            params[param_key] = migration[migration_key]
-    return params
+            new_params[param_key] = migration[migration_key]
+    return new_params
 
 
 def get_data(url, headers, params=None, logger=None):
@@ -163,13 +164,16 @@ def get_data(url, headers, params=None, logger=None):
         if data.status_code == 429:
             time.sleep(2 ** retry_count)  # Exponential backoff before retrying
         elif data.status_code == 301:
-            params = redirect(params, data.json()['data'][0])
+            new_params = redirect(params, data.json()['data'][0])
+            logger.warning('Redirecting {} to {}'.format(params, new_params), extra=log_record)
+            params = new_params
         elif data.status_code in [404, 401, 500]:
             break
         else:
             logger.error(data.text, extra=log_record)
     raise Exception('Giving up on {} after {} tries. Error is: {}.'.format(
         url, retry_count, data.text))
+
 
 @memoize(maxsize=None)
 def get_available(access_token, api_host, entity_type):
@@ -185,9 +189,9 @@ def get_available(access_token, api_host, entity_type):
     Returns
     -------
     data : list of dicts
-        
+
         Example::
-        
+
             [ { 'id': 0, 'contains': [1, 2, 3], 'name': 'World', 'level': 1},
             { 'id': 1, 'contains': [4, 5, 6], 'name': 'Asia', 'level': 2},
             ... ]
@@ -210,11 +214,11 @@ def list_available(access_token, api_host, selected_entities):
     access_token : string
     api_host : string
     selected_entities : dict
-        
+
         Example::
-        
+
             { 'metric_id': 123, 'item_id': 456, 'source_id': 7 }
-        
+
         Keys may include: metric_id, item_id, region_id, partner_region_id,
         source_id, frequency_id
 
@@ -241,6 +245,7 @@ def list_available(access_token, api_host, selected_entities):
         return resp.json()['data']
     except KeyError:
         raise Exception(resp.text)
+
 
 @memoize(maxsize=None)
 def lookup(access_token, api_host, entity_type, entity_id):
@@ -276,6 +281,7 @@ def lookup(access_token, api_host, entity_type, entity_id):
         return resp.json()['data']
     except KeyError:
         raise Exception(resp.text)
+
 
 @memoize(maxsize=None)
 def snake_to_camel(term):
@@ -415,9 +421,9 @@ def get_data_series(access_token, api_host, **selection):
     Returns
     -------
     list of dicts
-        
+
         Example::
-        
+
             [{ 'metric_id': 2020032, 'metric_name': 'Seed Use',
                'item_id': 274, 'item_name': 'Corn',
                'region_id': 1215, 'region_name': 'United States',
@@ -672,6 +678,7 @@ def get_data_points(access_token, api_host, **selection):
     resp = get_data(url, headers, params)
     return resp.json()
 
+
 @memoize(maxsize=None)
 def universal_search(access_token, api_host, search_terms):
     """Search across all entity types for the given terms.
@@ -685,7 +692,7 @@ def universal_search(access_token, api_host, search_terms):
     Returns
     -------
     list of [id, entity_type] pairs
-        
+
         Example::
 
             [[5604, 'item'], [10204, 'item'], [410032, 'metric'], ....]
@@ -696,6 +703,7 @@ def universal_search(access_token, api_host, search_terms):
     headers = {'authorization': 'Bearer ' + access_token}
     resp = get_data(url, headers, {'q': search_terms})
     return resp.json()
+
 
 @memoize(maxsize=None)
 def search(access_token, api_host, entity_type, search_terms):
@@ -712,7 +720,7 @@ def search(access_token, api_host, entity_type, search_terms):
     Returns
     -------
     list of dicts
-        
+
         Example::
 
             [{'id': 5604}, {'id': 10204}, {'id': 10210}, ....]
@@ -817,6 +825,7 @@ def get_geo_centre(access_token, api_host, region_id):
     headers = {'authorization': 'Bearer ' + access_token}
     resp = get_data(url, headers)
     return resp.json()['data']
+
 
 @memoize(maxsize=None)
 def get_geojson(access_token, api_host, region_id):

--- a/api/client/samples/batch_queries/batch_queries.py
+++ b/api/client/samples/batch_queries/batch_queries.py
@@ -9,11 +9,11 @@ def main():
 
     api_client = BatchClient(API_HOST, ACCESS_TOKEN)
 
-    # specify everything except region_id 
+    # specify everything except region_id
     selection = {
-        'metric_id': 860032, 
-        'item_id': 274, 
-        'source_id': 25, 
+        'metric_id': 860032,
+        'item_id': 274,
+        'source_id': 25,
         'frequency_id': 9,
         'start_date': '1998-01-01T00:00:00.000Z',
         'end_date': '1998-01-01T00:00:00.000Z'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pandas
 python-dateutil
 pytz
 requests
-tornado
+tornado>=5.1
 unicodecsv
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements-docs.txt", "r") as docs_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.40.1",
+    version="1.40.2",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
Tested using this script:

```py
    client = GroClient(API_HOST, ACCESS_TOKEN)
    bclient = BatchClient(API_HOST, ACCESS_TOKEN)

    old_ids = {
        'metric_id': 3680042,
        'item_id': 5937,
        'source_id': 28
    }

    new_ids = {
        'metric_id': 15851490,
        'item_id': 5937,
        'source_id': 28
    }

    selections = []

    for new_ds in client.get_data_series(**new_ids):
        new_ds['metric_id'] = old_ids['metric_id']
        new_ds['item_id'] = old_ids['item_id']
        selections.append(new_ds)
    
    # Test Batch Client
    for data_series in bclient.batch_async_get_data_points(selections):
        for point in data_series:
            print(point)

    # Test Gro Client
    for data_series in selections:
        for point in client.get_data_points(**data_series):
            print(point)
```

I found a specific case of a migration, then used `get_data_series()` to find all the affected series and request them using the old ids instead.

So now you get

```py
Queued 182 requests in 0.0006730556488037109
INFO:api.client.lib:Queued 182 requests in 0.0006730556488037109
HTTP 301: Moved Permanently
WARNING:api.client.lib:HTTP 301: Moved Permanently
Redirecting {'metricId': 3680042, 'itemId': 5937, 'regionId': 1027, 'sourceId': 28, 'partnerRegionId': 0, 'frequencyId': 9, 'startDate': '2007-01-01T00:00:00.000Z', 'endDate': '2018-12-31T00:00:00.000Z'} to {'metricId': 15851490, 'itemId': 5937, 'regionId': 1027, 'sourceId': 28, 'partnerRegionId': 0, 'frequencyId': 9, 'startDate': '2007-01-01T00:00:00.000Z', 'endDate': '2018-12-31T00:00:00.000Z'}
WARNING:api.client.lib:Redirecting {'metricId': 3680042, 'itemId': 5937, 'regionId': 1027, 'sourceId': 28, 'partnerRegionId': 0, 'frequencyId': 9, 'startDate': '2007-01-01T00:00:00.000Z', 'endDate': '2018-12-31T00:00:00.000Z'} to {'metricId': 15851490, 'itemId': 5937, 'regionId': 1027, 'sourceId': 28, 'partnerRegionId': 0, 'frequencyId': 9, 'startDate': '2007-01-01T00:00:00.000Z', 'endDate': '2018-12-31T00:00:00.000Z'}
...
{'start_date': '2016-01-01T00:00:00.000Z', 'end_date': '2016-12-31T00:00:00.000Z', 'value': 2.94179509432939, 'input_unit_id': 103, 'input_unit_scale': 1, 'metric_id': 15851490, 'item_id': 5937, 'region_id': 1250, 'frequency_id': 9, 'unit_id': 103}
{'start_date': '2017-01-01T00:00:00.000Z', 'end_date': '2017-12-31T00:00:00.000Z', 'value': 0.592151499045102, 'input_unit_id': 103, 'input_unit_scale': 1, 'metric_id': 15851490, 'item_id': 5937, 'region_id': 1250, 'frequency_id': 9, 'unit_id': 103}
{'start_date': '2018-01-01T00:00:00.000Z', 'end_date': '2018-12-31T00:00:00.000Z', 'value': 0.557744803915654, 'input_unit_id': 103, 'input_unit_scale': 1, 'metric_id': 15851490, 'item_id': 5937, 'region_id': 1250, 'frequency_id': 9, 'unit_id': 103}
```

Instead of before you would have gotten:

```py
HTTP 301: Moved Permanently
WARNING:api.client.lib:HTTP 301: Moved Permanently
ERROR:tornado.application:Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOMainLoop object at 0x1056f2d10>>, <Future finished exception=TypeError('the JSON object must be str, bytes or bytearray, not NoneType')>)
Traceback (most recent call last):
```