### PR TITLE
Clews 22325

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -50,6 +50,6 @@ class Client(object):
     def get_geojson(self, region_id):
         return lib.get_geojson(self.access_token, self.api_host, region_id)
 
-    def get_descendant_regions(self, region_id, descendant_level=None):
+    def get_descendant_regions(self, region_id, descendant_level=None, includeHistorical=True):
         return lib.get_descendant_regions(self.access_token, self.api_host,
-                                          region_id, descendant_level)
+                                          region_id, descendant_level, includeHistorical)

--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -50,6 +50,6 @@ class Client(object):
     def get_geojson(self, region_id):
         return lib.get_geojson(self.access_token, self.api_host, region_id)
 
-    def get_descendant_regions(self, region_id, descendant_level=None, includeHistorical=True):
+    def get_descendant_regions(self, region_id, descendant_level=None, include_historical=True):
         return lib.get_descendant_regions(self.access_token, self.api_host,
-                                          region_id, descendant_level, includeHistorical)
+                                          region_id, descendant_level, include_historical)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -873,6 +873,8 @@ def get_descendant_regions(access_token, api_host, region_id,
     region_id : integer
     descendant_level : integer
         The region level of interest. See REGION_LEVELS constant.
+    include_historical : boolean
+        option to include historical regions
 
     Returns
     -------

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -855,7 +855,7 @@ def get_geojson(access_token, api_host, region_id):
 
 
 def get_descendant_regions(access_token, api_host, region_id,
-                           descendant_level):
+                           descendant_level, include_historical):
     """Look up details of regions of the given level contained by a region.
 
     Given any region by id, recursively get all the descendant regions
@@ -899,11 +899,11 @@ def get_descendant_regions(access_token, api_host, region_id,
     region = lookup(access_token, api_host, 'regions', region_id)
     for member_id in region['contains']:
         member = lookup(access_token, api_host, 'regions', member_id)
-        if descendant_level == member['level'] and not member['historical']:
+        if descendant_level == member['level'] and (include_historical or not member['historical']):
             descendants.append(member)
         elif member['level'] < descendant_level:
             descendants += get_descendant_regions(
-                access_token, api_host, member_id, descendant_level)
+                access_token, api_host, member_id, descendant_level, include_historical)
     return descendants
 
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -855,7 +855,7 @@ def get_geojson(access_token, api_host, region_id):
 
 
 def get_descendant_regions(access_token, api_host, region_id,
-                           descendant_level, include_historical):
+                           descendant_level, include_historical=True):
     """Look up details of regions of the given level contained by a region.
 
     Given any region by id, recursively get all the descendant regions

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -899,7 +899,7 @@ def get_descendant_regions(access_token, api_host, region_id,
     region = lookup(access_token, api_host, 'regions', region_id)
     for member_id in region['contains']:
         member = lookup(access_token, api_host, 'regions', member_id)
-        if descendant_level == member['level']:
+        if descendant_level == member['level'] and not member['historical']:
             descendants.append(member)
         elif member['level'] < descendant_level:
             descendants += get_descendant_regions(

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -899,7 +899,9 @@ def get_descendant_regions(access_token, api_host, region_id,
     region = lookup(access_token, api_host, 'regions', region_id)
     for member_id in region['contains']:
         member = lookup(access_token, api_host, 'regions', member_id)
-        if descendant_level == member['level'] and (include_historical or not member['historical']):
+        if (not include_historical and member['historical']):
+            pass
+        elif descendant_level == member['level']:
             descendants.append(member)
         elif member['level'] < descendant_level:
             descendants += get_descendant_regions(


### PR DESCRIPTION
add option to omit historical regions within lib.get_descendant_regions, off by default. 

blocked by pr https://bitbucket.org/grointelligence/gro/pull-requests/12725/clews-22325-include-historical-field-when/diff

see 3) in this issue https://grointelligence.atlassian.net/browse/CLEWS-22325

> get_decedents should have the option to exclude historical regions from the response. This should not be the default option, but it should be an option.