### PR TITLE
V1.40.3 branch

### DIFF
--- a/api/client/samples/prevented_plant/README.md
+++ b/api/client/samples/prevented_plant/README.md
@@ -1,6 +1,6 @@
 # Gro API Client example: Prevented Plant
 
-1. Follow the [instructions to install the Gro API Client](../../../../README.md)
+1. Follow the [instructions to install the Gro API Client](../../../../README.md). NOTE: requires a minimum client version of v1.40.3.
 2. Download the [requirements file in this directory](./requirements.txt)
 3. Run `pip install -r requirements.txt` (for MacOS and Linux) or `conda install --file windows-requirements.txt` (for Windows) to automatically install the required dependencies (see comment in the notebook regarding xgboost)
 4. Download the notebook to your working directory

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements-docs.txt", "r") as docs_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.40.2",
+    version="1.40.3",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
The `get_logger()` feature added in https://github.com/gro-intelligence/api-client/pull/111/files#diff-603e79178b8e522d0e366a9fca477b24R44 needs to be included in a released version of the client library so prevent plant can utilize it. Tagging a new version so the update will be received.