### PR TITLE
CLEWS-20906 Remove crop calendar special casing

### DIFF
--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -6,8 +6,6 @@ from api.client import lib
 MOCK_HOST = "pytest.groclient.url"
 MOCK_TOKEN = "pytest.groclient.token"
 
-# TODO: Handle cases like the crop-calendar logic.
-
 def initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data={"data": [{"name": "obj1"}, {"name": "obj2"}, {"name": "obj3"}]}):
     mock_requests_get.return_value.json.return_value = mock_data
     mock_requests_get.return_value.status_code = 200


### PR DESCRIPTION
Used the following script to test:

```py
client = GroClient(API_HOST, ACCESS_TOKEN)
crop_calendar_id = client.search('metrics', 'crop calendar')[0]['id']
for data_series in client.get_data_series(metric_id=crop_calendar_id):
    for point in client.get_data_points(**data_series):
        print('\n', point)
    return
```

Before:

```py
 {'metric_id': 2260063, 'item_id': 3, 'region_id': 1155, 'frequency_id': 15, 'source_id': 5, 'start_date': '2017-10-09', 'end_date': '2017-11-19', 'value': 'planting', 'input_unit_id': None, 'input_unit_scale': None, 'reporting_date': None}

 {'metric_id': 2260063, 'item_id': 3, 'region_id': 1155, 'frequency_id': 15, 'source_id': 5, 'start_date': '2018-03-10', 'end_date': '2018-04-29', 'value': 'harvesting', 'input_unit_id': None, 'input_unit_scale': None, 'reporting_date': None}
```

After:

```py
 {'start_date': '2017-10-09T00:00:00.000Z', 'end_date': '2017-11-19T00:00:00.000Z', 'value': 'planting', 'reporting_date': '2015-06-29T00:00:00.000Z', 'input_unit_id': 7, 'input_unit_scale': 1, 'metric_id': 2260063, 'item_id': 3, 'region_id': 1155, 'partner_region_id': 0, 'frequency_id': 15, 'unit_id': 7}

 {'start_date': '2017-11-20T00:00:00.000Z', 'end_date': '2018-03-09T00:00:00.000Z', 'value': 'growing', 'reporting_date': '2015-06-29T00:00:00.000Z', 'input_unit_id': 7, 'input_unit_scale': 1, 'metric_id': 2260063, 'item_id': 3, 'region_id': 1155, 'partner_region_id': 0, 'frequency_id': 15, 'unit_id': 7}

 {'start_date': '2018-03-10T00:00:00.000Z', 'end_date': '2018-04-29T00:00:00.000Z', 'value': 'harvesting', 'reporting_date': '2015-06-29T00:00:00.000Z', 'input_unit_id': 7, 'input_unit_scale': 1, 'metric_id': 2260063, 'item_id': 3, 'region_id': 1155, 'partner_region_id': 0, 'frequency_id': 15, 'unit_id': 7}
```

Note the extra "growing" data point.

Also, since BatchClient overloads `get_data_points()` it never got the crop calendar special casing in the first place, so it's already on the new output anyway.