### PR TITLE
Prevent plant descartes

### DIFF
--- a/api/client/samples/prevented_plant/requirements.txt
+++ b/api/client/samples/prevented_plant/requirements.txt
@@ -5,3 +5,4 @@ geopandas
 ipython
 scikit-learn
 jupyter
+descartes

--- a/api/client/samples/prevented_plant/windows-requirements.txt
+++ b/api/client/samples/prevented_plant/windows-requirements.txt
@@ -4,3 +4,4 @@ geopandas
 ipython
 scikit-learn
 jupyter
+descartes


### PR DESCRIPTION
Got stuck on `county_data.plot("prevented_ratio_gbt", legend=True, ax=ax, cmap=blue_cmap)` without it.

"The descartes package is required for plotting polygons in geopandas"