### PR TITLE
simplify rank series by source

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -336,6 +336,9 @@ def get_source_ranking(access_token, api_host, series):
 def rank_series_by_source(access_token, api_host, series_list):
     for series in series_list:
         try:
+            # Remove source if selected, to consider all sources.
+            series.pop('source_name', None)
+            series.pop('source_id', None)
             source_ids = get_source_ranking(access_token, api_host, series)
         except ValueError:
             continue  # empty response

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -334,15 +334,7 @@ def get_source_ranking(access_token, api_host, series):
 
 
 def rank_series_by_source(access_token, api_host, series_list):
-    # We sort the internal tuple representations of the dictionaries because
-    # otherwise when we call set() we end up with duplicates if iteritems()
-    # returns a different order for the same dictionary. See test case.
-    selections_sorted = set(tuple(sorted(
-        [k_v for k_v in iter(list(single_series.items()))
-         if k_v[0] not in ('source_id', 'source_name')],
-        key=lambda x: x[0])) for single_series in series_list)
-
-    for series in map(dict, selections_sorted):
+    for series in series_list:
         try:
             source_ids = get_source_ranking(access_token, api_host, series)
         except ValueError:

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -191,19 +191,23 @@ def test_get_source_ranking(mock_requests_get):
 
 @mock.patch('requests.get')
 def test_rank_series_by_source(mock_requests_get):
-    mock_return = ["data1", "data2", "data3"]
+    # for each series selection, mock ranking of 3 source ids
+    mock_return = [11, 22, 33]
     mock_requests_get.return_value.json.return_value = mock_return
     mock_requests_get.return_value.status_code = 200
 
-    a = {"region_id": 13474, "abc": 123, "def": 123, "ghe": 123, "fij": 123, "item_id": 3457, "metric_id": 2540047}
+    a = {"region_id": 13474, "abc": 123, "def": 123, "ghe": 123, "fij": 123,
+         "item_id": 3457, "metric_id": 2540047,
+         "source_id": 123, "source_name": "dontcare"}
     a.pop("abc")
     a.pop("def")
     a.pop("ghe")
     a.pop("fij")
 
     b = {"item_id": 1457, "region_id": 13474, "metric_id": 2540047}
-
     c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a,b]))
-    # for each series selection a, b, we should get a ranking with 3 series
+
     assert(len(c) == 6)
+    for x in c:
+        assert "source_name" not in x
     assert mock_return + mock_return == [x["source_id"] for x in c]

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -195,16 +195,16 @@ def test_rank_series_by_source(mock_requests_get):
     mock_requests_get.return_value.json.return_value = mock_return
     mock_requests_get.return_value.status_code = 200
 
-    # Ordering of the dict should not matter
-    a = {"region_id": 13474, "abc": 123, "def": 123, "ghe": 123, "fij": 123, "item_id": 3457, "metric_id": 2540047, "source_id": 26}
+    a = {"region_id": 13474, "abc": 123, "def": 123, "ghe": 123, "fij": 123, "item_id": 3457, "metric_id": 2540047}
     a.pop("abc")
     a.pop("def")
     a.pop("ghe")
     a.pop("fij")
 
-    b = {"item_id": 3457, "region_id": 13474, "metric_id": 2540047, "source_id": 26}
+    b = {"item_id": 1457, "region_id": 13474, "metric_id": 2540047}
 
     c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a,b]))
-    assert(len(c) == 3)
+    # for each series selection a, b, we should get a ranking with 3 series
+    assert(len(c) == 6)
 
     assert mock_return == [x["source_id"] for x in c]

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -206,5 +206,4 @@ def test_rank_series_by_source(mock_requests_get):
     c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a,b]))
     # for each series selection a, b, we should get a ranking with 3 series
     assert(len(c) == 6)
-
-    assert mock_return == [x["source_id"] for x in c]
+    assert mock_return + mock_return == [x["source_id"] for x in c]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements-docs.txt", "r") as docs_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.40.4",
+    version="1.40.5",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
we remove teh bit that deals with duplicates in the list of series. this is over-optimization.
the caller can easily avoid duplicates, and if not, it's relatively harmless in ranking