### PR TITLE
CLEWS-20302 Hide branches from version switcher

### DIFF
--- a/docs/_static/css/custom-theme.css
+++ b/docs/_static/css/custom-theme.css
@@ -269,6 +269,6 @@ footer a {
 }
 
 /* hide branches from version switcher */
-.rst-other-versions:last-child {
+.rst-other-versions dl:last-child {
     display: none;
 }

--- a/docs/_static/css/custom-theme.css
+++ b/docs/_static/css/custom-theme.css
@@ -267,3 +267,8 @@ footer a {
 #text {
     display: none;
 }
+
+/* hide branches from version switcher */
+.rst-other-versions:last-child {
+    display: none;
+}


### PR DESCRIPTION
Should still display tags, but hide branches