### PR TITLE
Switch to list_of_series and add formatting function back to single_series

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -166,7 +166,7 @@ class Client(object):
         Yields
         ------
         dict
-            Result from search() passed to lookup() to get additional details.
+            Result from :meth:`search()` passed to :meth:`lookup()` to get additional details.
             
             Example::
 
@@ -175,7 +175,7 @@ class Client(object):
                   'name': 'Corn',
                   'definition': 'The seeds of the widely cultivated...' }
 
-            See output of lookup(). Note that as with search(), the first result is
+            See output of :meth:`lookup()`. Note that as with :meth:`search()`, the first result is
             the best match for the given search term(s).
 
         """
@@ -197,7 +197,7 @@ class Client(object):
             Result of lookup() on each entity the given entity belongs to.
 
             For example: For the region 'United States', one yielded result will be for
-            'North America.' The format of which matches the output of lookup()::
+            'North America.' The format of which matches the output of :meth:`lookup()`::
 
                 { 'id': 15,
                   'contains': [ 1008, 1009, 1012, 1215, ... ],
@@ -301,7 +301,7 @@ class Client(object):
                     'level': 4
                 }, ...]
 
-            See output of lookup()
+            See output of :meth:`lookup()`
 
         """
         return lib.get_descendant_regions(self.access_token, self.api_host,

--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -166,7 +166,7 @@ class Client(object):
         Yields
         ------
         dict
-            Result from :meth:`search()` passed to :meth:`lookup()` to get additional details.
+            Result from :meth:`~.search` passed to :meth:`~.lookup` to get additional details.
             
             Example::
 
@@ -175,7 +175,7 @@ class Client(object):
                   'name': 'Corn',
                   'definition': 'The seeds of the widely cultivated...' }
 
-            See output of :meth:`lookup()`. Note that as with :meth:`search()`, the first result is
+            See output of :meth:`~.lookup`. Note that as with :meth:`~.search`, the first result is
             the best match for the given search term(s).
 
         """
@@ -194,10 +194,10 @@ class Client(object):
         Yields
         ------
         dict
-            Result of lookup() on each entity the given entity belongs to.
+            Result of :meth:`~.lookup` on each entity the given entity belongs to.
 
             For example: For the region 'United States', one yielded result will be for
-            'North America.' The format of which matches the output of :meth:`lookup()`::
+            'North America.' The format of which matches the output of :meth:`~.lookup`::
 
                 { 'id': 15,
                   'contains': [ 1008, 1009, 1012, 1215, ... ],
@@ -216,7 +216,7 @@ class Client(object):
         Parameters
         ----------
         series_list : list of dicts
-            See the output of get_data_series().
+            See the output of :meth:`~.get_data_series`.
 
         Yields
         ------
@@ -301,7 +301,7 @@ class Client(object):
                     'level': 4
                 }, ...]
 
-            See output of :meth:`lookup()`
+            See output of :meth:`~.lookup`
 
         """
         return lib.get_descendant_regions(self.access_token, self.api_host,

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -87,7 +87,7 @@ class BatchClient(GroClient):
         headers = {'authorization': 'Bearer ' + self.access_token}
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
-        resp = yield lib.format_list_of_series(self.get_data(url, headers, params))
+        resp = yield lib.list_of_series_to_single_series(self.get_data(url, headers, params))
         raise gen.Return(json_decode(resp))
 
     def batch_async_get_data_points(self, batched_args, output_list=None,

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -87,7 +87,7 @@ class BatchClient(GroClient):
         headers = {'authorization': 'Bearer ' + self.access_token}
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
-        resp = yield self.get_data(url, headers, params)
+        resp = yield lib.format_list_of_series(self.get_data(url, headers, params))
         raise gen.Return(json_decode(resp))
 
     def batch_async_get_data_points(self, batched_args, output_list=None,

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,12 +115,12 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`GroClient.get_data_series()` into
-        :meth:`GroClient.get_data_points()` to check what series exist for some selections and then
+        Note: you can pass the output of :meth:`api.client.gro_client.GroClient..get_data_series()` into
+        :meth:`api.client.gro_client.GroClient..get_data_points()` to check what series exist for some selections and then
         retrieve the data points for those series. See /api/client/samples/quickstart.py for an
         example of this.
 
-        :meth:`GroClient.get_data_points()` also allows passing a list of ids for metric_id,
+        :meth:`api.client.gro_client.GroClient..get_data_points()` also allows passing a list of ids for metric_id,
         item_id, and/or region_id to get multiple series in a single request. This can be faster if
         requesting many series.
 
@@ -209,9 +209,9 @@ class GroClient(Client):
 
     def get_data_series_list(self):
         """Inspect the current list of saved data series contained in the GroClient.
-        
-        For use with :meth:`GroClient.get_df()`. Add new data series to the list using
-        :meth:`GroClient.add_data_series()` and :meth:`GroClient.add_single_data_series()`.
+
+        For use with :meth:`api.client.gro_client.GroClient..get_df()`. Add new data series to the list using
+        :meth:`api.client.gro_client.GroClient..add_data_series()` and :meth:`api.client.gro_client.GroClient..add_single_data_series()`.
 
         Returns
         -------

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -455,7 +455,6 @@ class GroClient(Client):
         self._logger.info("Outputing to file: {}".format(filename))
         writer = unicodecsv.writer(open(filename, 'wb'))
         for point in self.get_data_points(**data_series):
-            print(point)
             writer.writerow([point['start_date'],
                              point['end_date'],
                              point['value'],

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,8 +115,8 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`get_data_series` into
-        :meth:`get_data_points` to check what series exist for some selections and then
+        Note: you can pass the output of :meth:`self.get_data_series` into
+        :meth:`GroClient.get_data_points` to check what series exist for some selections and then
         retrieve the data points for those series. See /api/client/samples/quickstart.py for an
         example of this.
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -47,17 +47,18 @@ class GroClient(Client):
 
 
     def get_df(self):
-        """Call get_data_points() for each saved data series and return as a combined dataframe.
+        """Call :meth:`~.get_data_points` for each saved data series and return as a combined
+        dataframe.
         
-        Note you must have first called either add_data_series() or add_single_data_series() to save
-        data series into the GroClient's data_series_list. You can inspect the client's saved list
-        using get_data_series_list().
+        Note you must have first called either :meth:`~.add_data_series` or
+        :meth:`~.add_single_data_series` to save data series into the GroClient's data_series_list.
+        You can inspect the client's saved list using :meth:`~.get_data_series_list`.
 
         Returns
         -------
         pandas.DataFrame
-            The results to get_data_points() for all the saved series, appended together into a
-            single dataframe.
+            The results to :meth:`~.get_data_points` for all the saved series, appended together
+            into a single dataframe.
             See https://developers.gro-intelligence.com/data-point-definition.html
 
         """
@@ -115,14 +116,13 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`~.get_data_series` into
-        :meth:`~.GroClient.get_data_points` to check what series exist for some selections and then
-        retrieve the data points for those series. See /api/client/samples/quickstart.py for an
-        example of this.
+        Note: you can pass the output of :meth:`~.get_data_series` into :meth:`~.get_data_points`
+        to check what series exist for some selections and then retrieve the data points for those
+        series. See /api/client/samples/quickstart.py for an example of this.
 
-        :meth:`get_data_points` also allows passing a list of ids for metric_id,
-        item_id, and/or region_id to get multiple series in a single request. This can be faster if
-        requesting many series.
+        :meth:`~.get_data_points` also allows passing a list of ids for metric_id, item_id, and/or
+        region_id to get multiple series in a single request. This can be faster if requesting many
+        series.
 
         For example::
 
@@ -210,13 +210,13 @@ class GroClient(Client):
     def get_data_series_list(self):
         """Inspect the current list of saved data series contained in the GroClient.
 
-        For use with :meth:`get_df`. Add new data series to the list using
-        :meth:`add_data_series` and :meth:`add_single_data_series`.
+        For use with :meth:`~.get_df`. Add new data series to the list using
+        :meth:`~.add_data_series` and :meth:`~.add_single_data_series`.
 
         Returns
         -------
         list of dicts
-            A list of data_series objects, as returned by get_data_series().
+            A list of data_series objects, as returned by :meth:`~.get_data_series`.
 
         """
         return list(self._data_series_list)
@@ -225,12 +225,13 @@ class GroClient(Client):
     def add_single_data_series(self, data_series):
         """Save a data series object to the GroClient's data_series_list.
         
-        For use with get_df().
+        For use with :meth:`~.get_df`.
         
         Parameters
         ----------
         data_series : dict
-            A single data_series object, as returned by get_data_series() or find_data_series().
+            A single data_series object, as returned by :meth:`~.get_data_series` or
+            :meth:`~.find_data_series`.
             See https://developers.gro-intelligence.com/data-series-definition.html
 
         Returns
@@ -264,10 +265,9 @@ class GroClient(Client):
 
         See https://developers.gro-intelligence.com/data-series-definition.html
 
-        This method uses search() to find entities by name and
-        get_data_series() to find available data series for all
-        possible combinations of the entities, and
-        rank_series_by_source.
+        This method uses :meth:`~.search` to find entities by name and :meth:`~.get_data_series` to
+        find available data series for all possible combinations of the entities, and
+        :meth:`~.rank_series_by_source`.
 
         Parameters
         ----------
@@ -287,7 +287,7 @@ class GroClient(Client):
 
         See also
         --------
-        get_data_series()
+        ~.get_data_series
 
         """
         search_results = []
@@ -328,9 +328,9 @@ class GroClient(Client):
 
 
     def add_data_series(self, **kwargs):
-        """Adds the top result of find_data_series() to the saved data series list.
-        
-        For use with get_df().
+        """Adds the top result of :meth:`~.find_data_series` to the saved data series list.
+
+        For use with :meth:`~.get_df`.
 
         Parameters
         ----------
@@ -349,9 +349,9 @@ class GroClient(Client):
 
         See also
         --------
-        get_df()
-        add_single_data_series()
-        find_data_series()
+        ~.get_df
+        ~.add_single_data_series
+        ~.find_data_series
         
         """
         for the_data_series in self.find_data_series(**kwargs):
@@ -409,11 +409,11 @@ class GroClient(Client):
                     'level': 4
                 }, ...]
 
-            See output of lookup()
+            See output of :meth:`~.lookup`
 
         See Also
         --------
-        get_descendant_regions()
+        ~.get_descendant_regions
 
         """
         for region in self.search_and_lookup('regions', country_name):
@@ -520,7 +520,9 @@ class GroClient(Client):
 
 """Basic Gro API command line interface.
 
-Note that results are chosen randomly from matching selections, and so results are not deterministic. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.
+Note that results are chosen randomly from matching selections, and so results are not
+deterministic. This tool is useful for simple queries, but anything more complex should be done
+using the provided Python packages.
 
 Usage examples:
     gro_client --item=soybeans  --region=brazil --partner_region china --metric export

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,8 +115,8 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`self.get_data_series` into
-        :meth:`GroClient.get_data_points` to check what series exist for some selections and then
+        Note: you can pass the output of :meth:`~.get_data_series` into
+        :meth:`~.GroClient.get_data_points` to check what series exist for some selections and then
         retrieve the data points for those series. See /api/client/samples/quickstart.py for an
         example of this.
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,12 +115,12 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`api.client.gro_client.GroClient.get_data_series` into
-        :meth:`api.client.gro_client.GroClient.get_data_points` to check what series exist for some selections and then
+        Note: you can pass the output of :meth:`get_data_series` into
+        :meth:`get_data_points` to check what series exist for some selections and then
         retrieve the data points for those series. See /api/client/samples/quickstart.py for an
         example of this.
 
-        :meth:`api.client.gro_client.GroClient.get_data_points` also allows passing a list of ids for metric_id,
+        :meth:`get_data_points` also allows passing a list of ids for metric_id,
         item_id, and/or region_id to get multiple series in a single request. This can be faster if
         requesting many series.
 
@@ -210,8 +210,8 @@ class GroClient(Client):
     def get_data_series_list(self):
         """Inspect the current list of saved data series contained in the GroClient.
 
-        For use with :meth:`api.client.gro_client.GroClient.get_df`. Add new data series to the list using
-        :meth:`api.client.gro_client.GroClient.add_data_series` and :meth:`api.client.gro_client.GroClient.add_single_data_series`.
+        For use with :meth:`get_df`. Add new data series to the list using
+        :meth:`add_data_series` and :meth:`add_single_data_series`.
 
         Returns
         -------

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,12 +115,12 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of :meth:`api.client.gro_client.GroClient..get_data_series()` into
-        :meth:`api.client.gro_client.GroClient..get_data_points()` to check what series exist for some selections and then
+        Note: you can pass the output of :meth:`api.client.gro_client.GroClient.get_data_series` into
+        :meth:`api.client.gro_client.GroClient.get_data_points` to check what series exist for some selections and then
         retrieve the data points for those series. See /api/client/samples/quickstart.py for an
         example of this.
 
-        :meth:`api.client.gro_client.GroClient..get_data_points()` also allows passing a list of ids for metric_id,
+        :meth:`api.client.gro_client.GroClient.get_data_points` also allows passing a list of ids for metric_id,
         item_id, and/or region_id to get multiple series in a single request. This can be faster if
         requesting many series.
 
@@ -210,8 +210,8 @@ class GroClient(Client):
     def get_data_series_list(self):
         """Inspect the current list of saved data series contained in the GroClient.
 
-        For use with :meth:`api.client.gro_client.GroClient..get_df()`. Add new data series to the list using
-        :meth:`api.client.gro_client.GroClient..add_data_series()` and :meth:`api.client.gro_client.GroClient..add_single_data_series()`.
+        For use with :meth:`api.client.gro_client.GroClient.get_df`. Add new data series to the list using
+        :meth:`api.client.gro_client.GroClient.add_data_series` and :meth:`api.client.gro_client.GroClient.add_single_data_series`.
 
         Returns
         -------

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -91,7 +91,7 @@ class GroClient(Client):
 
             client.get_data_points(**{'metric_id': 860032,
                                       'item_id': 274,
-                                      'region_id': 1215,
+                                      'region_id': [1215,1216],
                                       'frequency_id': 9,
                                       'source_id': 2,
                                       'start_date': '2017-01-01',
@@ -118,6 +118,49 @@ class GroClient(Client):
         Note: you can pass the output of `get_data_series()` into `get_data_points()` in order to
         programmatically check what series exist for some selections and then retrieve the data
         points for those series. See /api/client/samples/quickstart.py for an example of this.
+
+        get_data_points also allows passing a list of ids for metric_id, item_id, and/or region_id
+        to get multiple series in a single request. This can be faster if requesting many series.
+
+        For example::
+
+            client.get_data_points(**{'metric_id': 860032,
+                                      'item_id': 274,
+                                      'region_id': [1215,1216],
+                                      'frequency_id': 9,
+                                      'source_id': 2,
+                                      'start_date': '2017-01-01',
+                                      'end_date': '2017-12-31',
+                                      'unit_id': 15})
+        Returns::
+
+            [{  'start_date': '2017-01-01T00:00:00.000Z',
+                'end_date': '2017-12-31T00:00:00.000Z',
+                'value': 408913833.8019222, 'unit_id': 15,
+                'reporting_date': None,
+                'metric_id': 860032, 'item_id': 274, 'region_id': 1215,
+                'partner_region_id': 0, 'frequency_id': 9, 'source_id': 2,
+                'belongs_to': {
+                    'metric_id': 860032,
+                    'item_id': 274,
+                    'region_id': 1215,
+                    'frequency_id': 9,
+                    'source_id': 2
+                }
+            }, { 'start_date': '2017-01-01T00:00:00.000Z',
+                 'end_date': '2017-12-31T00:00:00.000Z',
+                 'value': 340614.19507563586, 'unit_id': 15,
+                 'reporting_date': None,
+                 'metric_id': 860032, 'item_id': 274, 'region_id': 1216,
+                 'partner_region_id': 0, 'frequency_id': 9, 'source_id': 2,
+                 'belongs_to': {
+                    'metric_id': 860032,
+                    'item_id': 274,
+                    'region_id': 1216,
+                    'frequency_id': 9,
+                    'source_id': 2
+                 }
+            }]
 
         Parameters
         ----------

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -41,10 +41,8 @@ class GroClient(Client):
         self._data_series_queue = []  # added but not loaded in data frame
         self._data_frame = None
 
-
     def get_logger(self):
         return self._logger
-
 
     def get_df(self):
         """Call :meth:`~.get_data_points` for each saved data series and return as a combined
@@ -78,7 +76,8 @@ class GroClient(Client):
                 tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
             if self._data_frame is None:
                 self._data_frame = tmp
-                self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS if col in tmp.columns])
+                self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS
+                                            if col in tmp.columns])
             else:
                 self._data_frame = self._data_frame.merge(tmp, how='outer')
         return self._data_frame
@@ -118,7 +117,7 @@ class GroClient(Client):
 
         Note: you can pass the output of :meth:`~.get_data_series` into :meth:`~.get_data_points`
         to check what series exist for some selections and then retrieve the data points for those
-        series. See /api/client/samples/quickstart.py for an example of this.
+        series. See :sample:`quick_start.py` for an example of this.
 
         :meth:`~.get_data_points` also allows passing a list of ids for metric_id, item_id, and/or
         region_id to get multiple series in a single request. This can be faster if requesting many
@@ -192,7 +191,7 @@ class GroClient(Client):
             that does not have data.
         at_time : string, optional
             Estimate what data would have been available via Gro at a given time in the past. See
-            /api/client/samples/at-time-query-examples.ipynb for more details.
+            :sample:`at-time-query-examples.ipynb` for more details.
 
         Returns
         -------
@@ -221,7 +220,6 @@ class GroClient(Client):
         """
         return list(self._data_series_list)
 
-
     def add_single_data_series(self, data_series):
         """Save a data series object to the GroClient's data_series_list.
         
@@ -243,7 +241,6 @@ class GroClient(Client):
         self._data_series_queue.append(data_series)
         self._logger.info("Added {}".format(data_series))
         return
-
 
     def find_data_series(self, **kwargs):
         """Find the best possible  data series matching a combination of entities specified by name.
@@ -326,7 +323,6 @@ class GroClient(Client):
         for data_series in self.rank_series_by_source(all_data_series):
             yield data_series
 
-
     def add_data_series(self, **kwargs):
         """Adds the top result of :meth:`~.find_data_series` to the saved data series list.
 
@@ -359,7 +355,6 @@ class GroClient(Client):
             return
         return
 
-
     ###
     # Discovery shortcuts
     ###
@@ -382,7 +377,6 @@ class GroClient(Client):
             self._logger.debug("First result, out of {} {}: {}".format(
                 len(results), entity_type, result['id']))
             return result['id']
-
 
     def get_provinces(self, country_name):
         """Given the name of a country, find its provinces.
@@ -423,7 +417,6 @@ class GroClient(Client):
                 return provinces
         return None
 
-
     ###
     # Convenience methods that automatically fill in partial selections with random entities
     ###
@@ -443,7 +436,6 @@ class GroClient(Client):
         selected_entities.update(entities)
         return selected_entities
 
-
     def pick_random_data_series(self, selected_entities):
         """Given a selection of tentities, pick a random available data series the given selection
         of entities.
@@ -455,7 +447,6 @@ class GroClient(Client):
         selected_data_series = data_series_list[int(len(data_series_list)*random())]
         return selected_data_series
 
-
     # TODO: rename function to "write_..." rather than "print_..."
     def print_one_data_series(self, data_series, filename):
         """Output a data series to a CSV file."""
@@ -466,7 +457,6 @@ class GroClient(Client):
             writer.writerow([point['start_date'], point['end_date'],
                              point['value'] * point['input_unit_scale'],
                              self.lookup_unit_abbreviation(point['input_unit_id'])])
-
 
     def convert_unit(self, point, target_unit_id):
         """Convert the data point from one unit to another unit.
@@ -518,19 +508,19 @@ class GroClient(Client):
         return point
 
 
-"""Basic Gro API command line interface.
-
-Note that results are chosen randomly from matching selections, and so results are not
-deterministic. This tool is useful for simple queries, but anything more complex should be done
-using the provided Python packages.
-
-Usage examples:
-    gro_client --item=soybeans  --region=brazil --partner_region china --metric export
-    gro_client --item=sesame --region=ethiopia
-    gro_client --user_email=john.doe@example.com  --print_token
-For more information use --help
-"""
 def main():
+    """Basic Gro API command line interface.
+
+    Note that results are chosen randomly from matching selections, and so results are not
+    deterministic. This tool is useful for simple queries, but anything more complex should be done
+    using the provided Python packages.
+
+    Usage examples:
+        gro_client --item=soybeans  --region=brazil --partner_region china --metric export
+        gro_client --item=sesame --region=ethiopia
+        gro_client --user_email=john.doe@example.com  --print_token
+    For more information use --help
+    """
     parser = argparse.ArgumentParser(description="Gro API command line interface")
     parser.add_argument("--user_email")
     parser.add_argument("--user_password")
@@ -567,7 +557,8 @@ def main():
     if args.region:
         selected_entities['region_id'] = client.search_for_entity('regions', args.region)
     if args.partner_region:
-        selected_entities['partner_region_id'] = client.search_for_entity('regions', args.partner_region)
+        selected_entities['partner_region_id'] = client.search_for_entity('regions',
+                                                                          args.partner_region)
     if not selected_entities:
         selected_entities = client.pick_random_entities()
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -153,21 +153,6 @@ class GroClient(Client):
         -------
         list of dicts
 
-            Example ::
-
-                [ {
-                    'start_date': '2000-01-01T00:00:00.000Z',
-                    'end_date': '2000-12-31T00:00:00.000Z',
-                    'value': 251854000,
-                    'input_unit_id': 14,
-                    'input_unit_scale': 1,
-                    'metric_id': 860032,
-                    'item_id': 274,
-                    'region_id': 1215,
-                    'frequency_id': 9,
-                    'unit_id': 14
-                }, ...]
-
         """
         data_points = super(GroClient, self).get_data_points(**selections)
         # Apply unit conversion if a unit is specified

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -287,7 +287,7 @@ class GroClient(Client):
 
         See also
         --------
-        ~.get_data_series
+        :meth:`~.get_data_series`
 
         """
         search_results = []
@@ -349,9 +349,9 @@ class GroClient(Client):
 
         See also
         --------
-        ~.get_df
-        ~.add_single_data_series
-        ~.find_data_series
+        :meth:`~.get_df`
+        :meth:`~.add_single_data_series`
+        :meth:`~.find_data_series`
         
         """
         for the_data_series in self.find_data_series(**kwargs):
@@ -413,7 +413,7 @@ class GroClient(Client):
 
         See Also
         --------
-        ~.get_descendant_regions
+        :meth:`~.get_descendant_regions`
 
         """
         for region in self.search_and_lookup('regions', country_name):

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -115,12 +115,14 @@ class GroClient(Client):
                 }
             }]
 
-        Note: you can pass the output of `get_data_series()` into `get_data_points()` in order to
-        programmatically check what series exist for some selections and then retrieve the data
-        points for those series. See /api/client/samples/quickstart.py for an example of this.
+        Note: you can pass the output of :meth:`GroClient.get_data_series()` into
+        :meth:`GroClient.get_data_points()` to check what series exist for some selections and then
+        retrieve the data points for those series. See /api/client/samples/quickstart.py for an
+        example of this.
 
-        get_data_points also allows passing a list of ids for metric_id, item_id, and/or region_id
-        to get multiple series in a single request. This can be faster if requesting many series.
+        :meth:`GroClient.get_data_points()` also allows passing a list of ids for metric_id,
+        item_id, and/or region_id to get multiple series in a single request. This can be faster if
+        requesting many series.
 
         For example::
 
@@ -208,8 +210,8 @@ class GroClient(Client):
     def get_data_series_list(self):
         """Inspect the current list of saved data series contained in the GroClient.
         
-        For use with get_df(). Add new data series to the list using add_data_series() and
-        add_single_data_series().
+        For use with :meth:`GroClient.get_df()`. Add new data series to the list using
+        :meth:`GroClient.add_data_series()` and :meth:`GroClient.add_single_data_series()`.
 
         Returns
         -------

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -454,9 +454,11 @@ class GroClient(Client):
         self._logger.info("Outputing to file: {}".format(filename))
         writer = unicodecsv.writer(open(filename, 'wb'))
         for point in self.get_data_points(**data_series):
-            writer.writerow([point['start_date'], point['end_date'],
-                             point['value'] * point['input_unit_scale'],
-                             self.lookup_unit_abbreviation(point['input_unit_id'])])
+            print(point)
+            writer.writerow([point['start_date'],
+                             point['end_date'],
+                             point['value'],
+                             self.lookup_unit_abbreviation(point['unit_id'])])
 
     def convert_unit(self, point, target_unit_id):
         """Convert the data point from one unit to another unit.

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -91,7 +91,7 @@ class GroClient(Client):
 
             client.get_data_points(**{'metric_id': 860032,
                                       'item_id': 274,
-                                      'region_id': [1215,1216],
+                                      'region_id': 1215,
                                       'frequency_id': 9,
                                       'source_id': 2,
                                       'start_date': '2017-01-01',

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -212,7 +212,7 @@ def get_data(url, headers, params=None, logger=None):
             new_params = redirect(params, data.json()['data'][0])
             logger.warning('Redirecting {} to {}'.format(params, new_params), extra=log_record)
             params = new_params
-        elif data.status_code in [404, 401, 500]:
+        elif data.status_code in [400, 401, 404, 500]:
             break
         else:
             logger.error('{}'.format(data), extra=log_record)
@@ -455,6 +455,11 @@ def format_list_of_series(series_list):
 
 
 def get_data_points(access_token, api_host, **selection):
+    assert 'metric_id' in selection, 'metric_id is required'
+    assert 'item_id' in selection, 'item_id is required'
+    assert 'region_id' in selection, 'region_id is required'
+    assert 'source_id' in selection, 'source_id is required'
+    assert 'frequency_id' in selection, 'frequency_id is required'
     headers = {'authorization': 'Bearer ' + access_token}
     url = '/'.join(['https:', '', api_host, 'v2/data'])
     params = get_data_call_params(**selection)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -313,7 +313,7 @@ def get_data_call_params(**selection):
 
     >>> get_data_call_params(
     ...     metric_id=123, start_date='2012-01-01', unit_id=14
-    ... ) == {'startDate': '2012-01-01', 'metricId': 123}
+    ... ) == {'startDate': '2012-01-01', 'metricId': 123, 'responseType': 'list_of_series'}
     True
 
     Parameters
@@ -398,24 +398,55 @@ def list_of_series_to_single_series(series_list):
     """Convert list_of_series format from API back into the familiar single_series output format.
 
     >>> list_of_series_to_single_series([{
-    ...     'series': { 'metricId': 1, 'itemId': 2, 'regionId': 3, 'belongsTo': { 'itemId': 22 } },
+    ...     'series': { 'metricId': 1, 'itemId': 2, 'regionId': 3, 'unitId': 4, 'inputUnitId': 5,
+    ...                 'belongsTo': { 'itemId': 22 }
+    ...     },
     ...     'data': [
-    ...         ['2001-01-01', '2001-12-31', 123]
+    ...         ['2001-01-01', '2001-12-31', 123],
+    ...         ['2002-01-01', '2002-12-31', 123, '2012-01-01'],
+    ...         ['2003-01-01', '2003-12-31', 123, None, {}]
     ...     ]
     ... }]) == [
     ...   { 'start_date': '2001-01-01',
     ...     'end_date': '2001-12-31',
     ...     'value': 123,
-    ...     'unit_id': None,
+    ...     'unit_id': 4,
+    ...     'input_unit_id': 4,
+    ...     'input_unit_scale': 1,
     ...     'reporting_date': None,
     ...     'metric_id': 1,
     ...     'item_id': 2,
     ...     'region_id': 3,
     ...     'partner_region_id': 0,
     ...     'frequency_id': None,
-    ...     'source_id': None,
-    ...     'belongs_to': { 'item_id': 22 }
-    ... } ]
+    ...     'belongs_to': { 'item_id': 22 } },
+    ...   { 'start_date': '2002-01-01',
+    ...     'end_date': '2002-12-31',
+    ...     'value': 123,
+    ...     'unit_id': 4,
+    ...     'input_unit_id': 4,
+    ...     'input_unit_scale': 1,
+    ...     'reporting_date': '2012-01-01',
+    ...     'metric_id': 1,
+    ...     'item_id': 2,
+    ...     'region_id': 3,
+    ...     'partner_region_id': 0,
+    ...     'frequency_id': None,
+    ...     'belongs_to': { 'item_id': 22 } },
+    ...   { 'start_date': '2003-01-01',
+    ...     'end_date': '2003-12-31',
+    ...     'value': 123,
+    ...     'unit_id': 4,
+    ...     'input_unit_id': 4,
+    ...     'input_unit_scale': 1,
+    ...     'reporting_date': None,
+    ...     'metric_id': 1,
+    ...     'item_id': 2,
+    ...     'region_id': 3,
+    ...     'partner_region_id': 0,
+    ...     'frequency_id': None,
+    ...     'belongs_to': { 'item_id': 22 } }
+    ... ]
     True
 
     """
@@ -449,7 +480,7 @@ def list_of_series_to_single_series(series_list):
             'region_id': series['series'].get('regionId', None),
             'partner_region_id': series['series'].get('partnerRegionId', 0),
             'frequency_id': series['series'].get('frequencyId', None),
-            'source_id': series['series'].get('sourceId', None),
+            # 'source_id': series['series'].get('sourceId', None), TODO: add source to output
             # belongs_to is consistent with the series the user requested. So if an
             # expansion happened on the server side, the user can reconstruct what
             # results came from which request.

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -437,6 +437,10 @@ def list_of_series_to_single_series(series_list):
             # list_of_series has unit_id in the series attributes currently. Does
             # not allow for mixed units in the same series
             'unit_id': series['series'].get('unitId', None),
+            # input_unit_id and input_unit_scale are deprecated but provided for backwards
+            # compatibility. unit_id should be used instead.
+            'input_unit_id': series['series'].get('unitId', None),
+            'input_unit_scale': 1,
             # If a point does not have reporting_date, use None
             'reporting_date': point[3] if len(point) > 3 else None,
             # Series attributes:

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -394,10 +394,10 @@ def rank_series_by_source(access_token, api_host, series_list):
             yield series_with_source
 
 
-def format_list_of_series(series_list):
+def list_of_series_to_single_series(series_list):
     """Convert list_of_series format from API back into the familiar single_series output format.
 
-    >>> format_list_of_series([{
+    >>> list_of_series_to_single_series([{
     ...     'series': { 'metricId': 1, 'itemId': 2, 'regionId': 3, 'belongsTo': { 'itemId': 22 } },
     ...     'data': [
     ...         ['2001-01-01', '2001-12-31', 123]
@@ -464,7 +464,7 @@ def get_data_points(access_token, api_host, **selection):
     url = '/'.join(['https:', '', api_host, 'v2/data'])
     params = get_data_call_params(**selection)
     resp = get_data(url, headers, params)
-    return format_list_of_series(resp.json())
+    return list_of_series_to_single_series(resp.json())
 
 
 @memoize(maxsize=None)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -490,11 +490,6 @@ def list_of_series_to_single_series(series_list):
 
 
 def get_data_points(access_token, api_host, **selection):
-    assert 'metric_id' in selection, 'metric_id is required'
-    assert 'item_id' in selection, 'item_id is required'
-    assert 'region_id' in selection, 'region_id is required'
-    assert 'source_id' in selection, 'source_id is required'
-    assert 'frequency_id' in selection, 'frequency_id is required'
     headers = {'authorization': 'Bearer ' + access_token}
     url = '/'.join(['https:', '', api_host, 'v2/data'])
     params = get_data_call_params(**selection)

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -132,6 +132,8 @@ def test_get_data_points(mock_requests_get):
         'end_date': '2000-12-31',
         'value': 1,
         'unit_id': None,
+        'input_unit_id': None,
+        'input_unit_scale': 1,
         'reporting_date': None,
         'metric_id': None,
         'item_id': None,

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -1,37 +1,39 @@
-import pytest
 import mock
 
 from api.client import lib
 
-MOCK_HOST = "pytest.groclient.url"
-MOCK_TOKEN = "pytest.groclient.token"
+MOCK_HOST = 'pytest.groclient.url'
+MOCK_TOKEN = 'pytest.groclient.token'
 
 
 def initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data={
-    "data": [
-        {"name": "obj1"},
-        {"name": "obj2"},
-        {"name": "obj3"}
+    'data': [
+        {'name': 'obj1'},
+        {'name': 'obj2'},
+        {'name': 'obj3'}
     ]}
 ):
     mock_requests_get.return_value.json.return_value = mock_data
     mock_requests_get.return_value.status_code = 200
     return mock_data
 
+
 @mock.patch('requests.get')
 def test_get_available(mock_requests_get):
     mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get)
 
     # Test data
-    entity_types = ["items", "metrics", "regions"]
+    entity_types = ['items', 'metrics', 'regions']
 
     for ent_type in entity_types:
-        assert lib.get_available(MOCK_TOKEN, MOCK_HOST, ent_type) == mock_data["data"]
+        assert lib.get_available(MOCK_TOKEN, MOCK_HOST, ent_type) == mock_data['data']
         # Make sure that call now exists in the mock call stack
-        mock_requests_get.assert_has_calls([mock.call('https://pytest.groclient.url/v2/' + ent_type,
-                  headers={'authorization': 'Bearer pytest.groclient.token'},
-                  params=None,
-                  timeout=None)])
+        mock_requests_get.assert_has_calls([
+            mock.call('https://pytest.groclient.url/v2/' + ent_type,
+                      headers={'authorization': 'Bearer pytest.groclient.token'},
+                      params=None,
+                      timeout=None)])
+
 
 @mock.patch('requests.get')
 def test_list_available(mock_requests_get):
@@ -40,25 +42,26 @@ def test_list_available(mock_requests_get):
 
     entities = {'metricId': '123', 'itemId': '456', 'regionId': '789'}
 
-    assert lib.list_available(MOCK_TOKEN, MOCK_HOST, entities) == mock_data["data"]
+    assert lib.list_available(MOCK_TOKEN, MOCK_HOST, entities) == mock_data['data']
 
     # Make sure that call now exists in the mock call stack
     mock_requests_get.assert_has_calls(
         [mock.call('https://pytest.groclient.url/v2/entities/list',
-            headers={'authorization': 'Bearer pytest.groclient.token'},
-            params=entities,
-            timeout=None)]
+                   headers={'authorization': 'Bearer pytest.groclient.token'},
+                   params=entities,
+                   timeout=None)]
     )
+
 
 @mock.patch('requests.get')
 def test_list_available_snake_to_camel(mock_requests_get):
-    #Tests that the camel-ing fix is working properly.
+    # Tests that the camel-ing fix is working properly.
     mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get)
 
     entities = {'metric_id': '123', 'item_id': '456', 'regionId': '789'}
     entities_camel = {'metricId': '123', 'itemId': '456', 'regionId': '789'}
 
-    assert lib.list_available(MOCK_TOKEN, MOCK_HOST, entities) == mock_data["data"]
+    assert lib.list_available(MOCK_TOKEN, MOCK_HOST, entities) == mock_data['data']
 
     # Make sure that call now exists in the mock call stack
     mock_requests_get.assert_has_calls(
@@ -68,15 +71,16 @@ def test_list_available_snake_to_camel(mock_requests_get):
                    timeout=None)]
     )
 
+
 @mock.patch('requests.get')
 def test_lookup(mock_requests_get):
     mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get)
 
     # test data
-    entity_types = ["items", "metrics", "regions", "units", "sources"]
+    entity_types = ['items', 'metrics', 'regions', 'units', 'sources']
 
     for ent_type in entity_types:
-        assert lib.lookup(MOCK_TOKEN, MOCK_HOST, ent_type, 12345) == mock_data["data"]
+        assert lib.lookup(MOCK_TOKEN, MOCK_HOST, ent_type, 12345) == mock_data['data']
 
         # Make sure that call now exists in the mock call stack
         mock_requests_get.assert_has_calls(
@@ -90,28 +94,32 @@ def test_lookup(mock_requests_get):
 # @mock.patch('api.client.Client.lookup')
 # def test_lookup_unit_abbreviation(lookup_mocked):
 #
-#     lookup_mocked.return_value = {"abbreviation": "test123"}
-#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, "kg") ==  "test123"
-#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, "kg") ==  "test123"
-#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, "kg") ==  "test123"
-#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, "mg") == "test123"
+#     lookup_mocked.return_value = {'abbreviation': 'test123'}
+#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, 'kg') ==  'test123'
+#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, 'kg') ==  'test123'
+#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, 'kg') ==  'test123'
+#     assert lib.lookup_unit_abbreviation(MOCK_TOKEN, MOCK_HOST, 'mg') == 'test123'
 #
 #     # Make sure it caches properly
 #     assert lookup_mocked.call_args_list == [mock.call('units', 'kg'), mock.call('units', 'mg')]
+
 
 @mock.patch('requests.get')
 def test_get_data_series(mock_requests_get):
     # Test general case
     mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get)
-    selection_dict = {"item_id": 123, "metric_id": 456, "region_id": 789, "partner_region_id": 161718, "frequency_id": 101112, "source_id": 12}
+    selection_dict = {'item_id': 123, 'metric_id': 456, 'region_id': 789,
+                      'partner_region_id': 161718, 'frequency_id': 101112, 'source_id': 12}
 
-    assert lib.get_data_series(MOCK_TOKEN, MOCK_HOST, **selection_dict) == mock_data["data"]
+    assert lib.get_data_series(MOCK_TOKEN, MOCK_HOST, **selection_dict) == mock_data['data']
 
     # Make sure that call now exists in the mock call stack
     assert [mock.call('https://pytest.groclient.url/v2/data_series/list',
-                                headers={'authorization': 'Bearer pytest.groclient.token'},
-                                params={'itemId': 123, 'metricId': 456, 'regionId': 789, 'partnerRegionId': 161718, 'frequencyId': 101112, 'sourceId': 12},
-                                timeout=None)] == mock_requests_get.call_args_list
+                      headers={'authorization': 'Bearer pytest.groclient.token'},
+                      params={'itemId': 123, 'metricId': 456, 'regionId': 789,
+                              'partnerRegionId': 161718, 'frequencyId': 101112, 'sourceId': 12},
+                      timeout=None)] == mock_requests_get.call_args_list
+
 
 @mock.patch('requests.get')
 def test_get_data_points(mock_requests_get):
@@ -133,73 +141,83 @@ def test_get_data_points(mock_requests_get):
         'source_id': None,
         'belongs_to': {}
     }]
-    mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get,
-                                                             mock_data=list_of_series_format_data)
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get,
+                                                 mock_data=list_of_series_format_data)
 
     # Test data
-    selection_dict = {"item_id": 123, "metric_id": 456, "region_id": 789,
-                      "frequency_id": 101112, "source_id": 131415, "partner_region_id": 161718}
+    selection_dict = {'item_id': 123, 'metric_id': 456, 'region_id': 789,
+                      'frequency_id': 101112, 'source_id': 131415, 'partner_region_id': 161718}
 
     assert lib.get_data_points(MOCK_TOKEN, MOCK_HOST, **selection_dict) == single_series_format_data
 
     # Make sure that call now exists in the mock call stack
     assert [mock.call('https://pytest.groclient.url/v2/data',
-                                headers={'authorization': 'Bearer pytest.groclient.token'},
-                                params={'itemId': 123, 'regionId': 789, 'partnerRegionId': 161718,
-                                        'sourceId': 131415, 'metricId': 456, 'frequencyId': 101112},
-                                timeout=None)] == mock_requests_get.call_args_list
+                      headers={'authorization': 'Bearer pytest.groclient.token'},
+                      params={'itemId': 123, 'regionId': 789, 'partnerRegionId': 161718,
+                              'sourceId': 131415, 'metricId': 456, 'frequencyId': 101112,
+                              'responseType': 'list_of_series'},
+                      timeout=None)] == mock_requests_get.call_args_list
+
 
 @mock.patch('requests.get')
 def test_search(mock_requests_get):
-    mock_data = ["obj1", "obj2", "obj3"]
+    mock_data = ['obj1', 'obj2', 'obj3']
     mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data=mock_data)
 
-    assert lib.search(MOCK_TOKEN, MOCK_HOST, "items", "test123") == mock_data
+    assert lib.search(MOCK_TOKEN, MOCK_HOST, 'items', 'test123') == mock_data
 
     assert [mock.call('https://pytest.groclient.url/v2/search/items',
-                                headers={'authorization': 'Bearer pytest.groclient.token'},
-                                params={'q': 'test123'},
-                                timeout=None)] == mock_requests_get.call_args_list
+                      headers={'authorization': 'Bearer pytest.groclient.token'},
+                      params={'q': 'test123'},
+                      timeout=None)] == mock_requests_get.call_args_list
+
 
 @mock.patch('api.client.lib.lookup')
 @mock.patch('api.client.lib.search')
 def test_search_and_lookup(search_mocked, lookup_mocked):
     # Set up
     # mock return values
-    search_mocked.return_value = [{"id": "test1"}, {"id": "test2"}]
-    mock_data = ["obj1", "obj2"]
+    search_mocked.return_value = [{'id': 'test1'}, {'id': 'test2'}]
+    mock_data = ['obj1', 'obj2']
     lookup_mocked.return_value = mock_data
-    search_and_lookup_result = list(lib.search_and_lookup(MOCK_TOKEN, MOCK_HOST, "items", "test123"))
+    search_and_lookup_result = list(lib.search_and_lookup(MOCK_TOKEN, MOCK_HOST,
+                                                          'items', 'test123'))
 
     assert search_and_lookup_result == [mock_data]*2
 
-    assert [mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test123')] == search_mocked.mock_calls
-    assert [mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test1'),
-            mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test2')] == lookup_mocked.mock_calls
+    assert [
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test123')
+    ] == search_mocked.mock_calls
+    assert [
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test1'),
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 'test2')
+    ] == lookup_mocked.mock_calls
+
 
 @mock.patch('api.client.lib.lookup')
 @mock.patch('requests.get')
 def test_lookup_belongs(mock_requests_get, lookup_mocked):
     # Set up
     # mock return values
-    mock_data = ["obj1", "obj2"]
-    mock_requests_get.return_value.json.return_value = {"data": {"test_entity": [1,2,3]}}
+    mock_data = ['obj1', 'obj2']
+    mock_requests_get.return_value.json.return_value = {'data': {'test_entity': [1, 2, 3]}}
     mock_requests_get.return_value.status_code = 200
     lookup_mocked.return_value = mock_data
 
-    lookup_belongs_result = list(lib.lookup_belongs(MOCK_TOKEN, MOCK_HOST, "items", "test_entity"))
+    lookup_belongs_result = list(lib.lookup_belongs(MOCK_TOKEN, MOCK_HOST, 'items', 'test_entity'))
 
     assert [mock_data]*3 == lookup_belongs_result
 
     assert [mock.call('https://pytest.groclient.url/v2/items/belongs-to',
-                                headers={'authorization': 'Bearer pytest.groclient.token'},
-                                params={'ids': 'test_entity'},
-                                timeout=None)] == mock_requests_get.call_args_list
+                      headers={'authorization': 'Bearer pytest.groclient.token'},
+                      params={'ids': 'test_entity'},
+                      timeout=None)] == mock_requests_get.call_args_list
 
-    assert [mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 1),
-                     mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 2),
-                     mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 3)] \
-           == lookup_mocked.mock_calls
+    assert [
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 1),
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 2),
+        mock.call('pytest.groclient.token', 'pytest.groclient.url', 'items', 3)
+    ] == lookup_mocked.mock_calls
 
 
 @mock.patch('requests.get')
@@ -221,18 +239,18 @@ def test_rank_series_by_source(mock_requests_get):
     mock_requests_get.return_value.json.return_value = mock_return
     mock_requests_get.return_value.status_code = 200
 
-    a = {"region_id": 13474, "abc": 123, "def": 123, "ghe": 123, "fij": 123,
-         "item_id": 3457, "metric_id": 2540047,
-         "source_id": 123, "source_name": "dontcare"}
-    a.pop("abc")
-    a.pop("def")
-    a.pop("ghe")
-    a.pop("fij")
+    a = {'region_id': 13474, 'abc': 123, 'def': 123, 'ghe': 123, 'fij': 123,
+         'item_id': 3457, 'metric_id': 2540047,
+         'source_id': 123, 'source_name': 'dontcare'}
+    a.pop('abc')
+    a.pop('def')
+    a.pop('ghe')
+    a.pop('fij')
 
-    b = {"item_id": 1457, "region_id": 13474, "metric_id": 2540047}
-    c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a,b]))
+    b = {'item_id': 1457, 'region_id': 13474, 'metric_id': 2540047}
+    c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a, b]))
 
     assert(len(c) == 6)
     for x in c:
-        assert "source_name" not in x
-    assert mock_return + mock_return == [x["source_id"] for x in c]
+        assert 'source_name' not in x
+    assert mock_return + mock_return == [x['source_id'] for x in c]

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -140,7 +140,7 @@ def test_get_data_points(mock_requests_get):
         'region_id': None,
         'partner_region_id': 0,
         'frequency_id': None,
-        'source_id': None,
+        # 'source_id': None, TODO: add source to output
         'belongs_to': {}
     }]
     initialize_requests_mocker_and_get_mock_data(mock_requests_get,

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -6,7 +6,14 @@ from api.client import lib
 MOCK_HOST = "pytest.groclient.url"
 MOCK_TOKEN = "pytest.groclient.token"
 
-def initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data={"data": [{"name": "obj1"}, {"name": "obj2"}, {"name": "obj3"}]}):
+
+def initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data={
+    "data": [
+        {"name": "obj1"},
+        {"name": "obj2"},
+        {"name": "obj3"}
+    ]}
+):
     mock_requests_get.return_value.json.return_value = mock_data
     mock_requests_get.return_value.status_code = 200
     return mock_data
@@ -108,14 +115,32 @@ def test_get_data_series(mock_requests_get):
 
 @mock.patch('requests.get')
 def test_get_data_points(mock_requests_get):
-    mock_data = ["obj1", "obj2", "obj3"]
-    mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get, mock_data=mock_data)
+    list_of_series_format_data = [{
+        'series': {},
+        'data': [['2000-01-01', '2000-12-31', 1]]
+    }]
+    single_series_format_data = [{
+        'start_date': '2000-01-01',
+        'end_date': '2000-12-31',
+        'value': 1,
+        'unit_id': None,
+        'reporting_date': None,
+        'metric_id': None,
+        'item_id': None,
+        'region_id': None,
+        'partner_region_id': 0,
+        'frequency_id': None,
+        'source_id': None,
+        'belongs_to': {}
+    }]
+    mock_data = initialize_requests_mocker_and_get_mock_data(mock_requests_get,
+                                                             mock_data=list_of_series_format_data)
 
     # Test data
     selection_dict = {"item_id": 123, "metric_id": 456, "region_id": 789,
                       "frequency_id": 101112, "source_id": 131415, "partner_region_id": 161718}
 
-    assert lib.get_data_points(MOCK_TOKEN, MOCK_HOST, **selection_dict) == mock_data
+    assert lib.get_data_points(MOCK_TOKEN, MOCK_HOST, **selection_dict) == single_series_format_data
 
     # Make sure that call now exists in the mock call stack
     assert [mock.call('https://pytest.groclient.url/v2/data',

--- a/api/client/samples/crop_models/sugar.py
+++ b/api/client/samples/crop_models/sugar.py
@@ -61,9 +61,10 @@ def main():
         writer = unicodecsv.writer(open(filename, 'wb'))
         count = 0
         for point in model.get_data_points(**data_series):
-            writer.writerow([point['start_date'], point['end_date'],
-                             point['value'] * point['input_unit_scale'],
-                             model.lookup_unit_abbreviation(point['input_unit_id'])])
+            writer.writerow([point['start_date'],
+                             point['end_date'],
+                             point['value'],
+                             model.lookup_unit_abbreviation(point['unit_id'])])
             count += 1
         print("Output {} rows to {}".format(count, filename))
 

--- a/api/client/samples/quick_start.py
+++ b/api/client/samples/quick_start.py
@@ -29,7 +29,7 @@ def main():
                 point['start_date'],
                 point['end_date'],
                 point['value'],
-                client.lookup_unit_abbreviation(point['input_unit_id'])
+                client.lookup_unit_abbreviation(point['unit_id'])
             ])
 
 

--- a/api/client/samples/quick_start.py
+++ b/api/client/samples/quick_start.py
@@ -10,9 +10,9 @@ ACCESS_TOKEN = os.environ['GROAPI_TOKEN']
 def main():
     client = GroClient(API_HOST, ACCESS_TOKEN)
 
-    selected_entities = {u'region_id': 1210,  # Ukraine
-                         u'item_id': 95,  # Wheat
-                         u'metric_id': 570001}  # Area Harvested (area)
+    selected_entities = {'region_id': 1210,  # Ukraine
+                         'item_id': 95,  # Wheat
+                         'metric_id': 570001}  # Area Harvested (area)
 
     writer = unicodecsv.writer(open(OUTPUT_FILENAME, 'wb'))
 

--- a/docs/_static/css/custom-theme.css
+++ b/docs/_static/css/custom-theme.css
@@ -268,6 +268,11 @@ footer a {
     display: none;
 }
 
+/* Make method links like :meth:`~.get_data_points` not tiny */
+code, .rst-content tt, .rst-content code {
+    font-size: 100% !important;
+}
+
 /* hide branches from version switcher */
 .rst-other-versions dl:last-child {
     display: none;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,11 @@ author = 'Gro Intelligence'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode',
+    'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
     'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
     'recommonmark'
 ]
 
@@ -67,6 +68,14 @@ html_theme_options = {
 }
 
 html_style = 'css/custom-theme.css'
+
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
+extlinks = {
+    'sample': (
+        'https://github.com/gro-intelligence/api-client/tree/development/api/client/samples/%s',
+        'sample '
+    )
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,7 @@ html_style = 'css/custom-theme.css'
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 extlinks = {
     'sample': (
-        'https://github.com/gro-intelligence/api-client/tree/development/api/client/samples/%s',
-        'sample '
+        'https://github.com/gro-intelligence/api-client/tree/development/api/client/samples/%s', ''
     )
 }
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements-docs.txt", "r") as docs_requirements_file:
 
 setuptools.setup(
     name="gro",
-    version="1.40.5",
+    version="1.56.0",
     description="Python client library for accessing Gro Intelligence's "
                 "agricultural data platform",
     long_description=long_description,


### PR DESCRIPTION
See the test case: https://github.com/gro-intelligence/api-client/compare/CLEWS-20278-mvp?expand=1#diff-7ed38827a2c4e58f0dd776f8639dc95cR400

"list_of_series" output is in the format:

```py
{
  'series': { 'metricId': 1, 'itemId': 2, 'regionId': 3, 'belongsTo': { 'itemId': 22 } },
  'data': [
    ['2001-01-01', '2001-12-31', 123]
  ]
}
```

The formatter function translates that back into the normal "single_series" format API client's always used, just with the addition of the belongs_to property:

```py
[ {
    'start_date': '2001-01-01',
    'end_date': '2001-12-31',
    'value': 123,
    'unit_id': None,
    'reporting_date': None,
    'metric_id': 1,
    'item_id': 2,
    'region_id': 3,
    'partner_region_id': 0,
    'frequency_id': None,
    'source_id': None,
    'belongs_to': { 'item_id': 22 }
} ]
```

The list_of_series format reduces the amount of duplicate info transmitted in data requests, and the addition of the belongs_to property allows us to request multiple series in a single request while still being able to figure out what data came from which requested series in the event of expansions. For example:

```py
from api.client.gro_client import GroClient
import os
client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])

request_response = { 100000021: set(), 100000022: set() }

for point in client.get_data_points(
  metric_id=30032,
  item_id=223,
  region_id=[100000021, 100000022],
  source_id=59,
  frequency_id=6,
  start_date='2010-01-01',
  end_date='2010-12-31'
):
  request_response[point['belongs_to']['region_id']].add(point['region_id'])

print(request_response)
```

outputs

```py
{100000021: {1096, 1105, 1075, 1011, 1205}, 100000022: {1092, 1032, 1162, 1134, 1167, 1210, 1051, 1183}}
```

If we didn't have the belongs_to property, we'd have points with region_ids 1096, 1105, 1075, 1011, 1205, 1092, 1032, 1162, 1134, 1167, 1210, 1051, and 1183, none of which are the regions we requested. We wouldn't know which ones belong to 100000021 and which ones belong to 100000022 without making additional queries.

## Further work:

I separated this PR out from my larger branch https://github.com/gro-intelligence/api-client/pull/116/files to serve as an MVP to get list_of_series out there and usable. Nice-to-haves in the other branch include:

1. If you request too many entities in a single request, automatically split it up into multiple requests instead of returning an error. In this PR, selecting an appropriate size request is the responsibility of the user
2. Group BatchClient requests together automatically under the hood. In this PR, you're able to make grouped requests using BatchClient in the same way you do with GroClient: making `region_id` or `item_id` into a list of integers instead of an integer. But if you pass in integers, it's an optimization we can make to group them for you without you doing anything.