### PR TITLE
convert batch_client returned objects back to be same as gro_client

### DIFF
--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -87,13 +87,14 @@ class BatchClient(GroClient):
         headers = {'authorization': 'Bearer ' + self.access_token}
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
-        resp = yield lib.list_of_series_to_single_series(self.get_data(url, headers, params))
+        resp = yield self.get_data(url, headers, params)
         raise gen.Return(json_decode(resp))
 
     def batch_async_get_data_points(self, batched_args, output_list=None,
                                     map_result=None):
-        return self.batch_async_queue(self.get_data_points, batched_args,
+        batch_async_series_list = self.batch_async_queue(self.get_data_points, batched_args,
                                       output_list, map_result)
+        return [lib.list_of_series_to_single_series(series_list) for series_list in batch_async_series_list]
 
     @gen.coroutine
     def async_rank_series_by_source(self, **selection):


### PR DESCRIPTION
This is a follow up fix for https://github.com/gro-intelligence/api-client/pull/141

When testing batch_client with the following code
```from api.client.batch_client import BatchClient
API_HOST = 'api.gro-intelligence.com'
TOKEN = USE_YOUR_OWN_TOKEN
batch_client_prod = BatchClient(API_HOST, TOKEN)
input_list = [{'frequency_id': 15,
  'item_id': 8819,
  'metric_id': 15530037,
  'region_id': 1215,
  'source_id': 87}]
batch_output_prod = batch_client_prod.batch_async_get_data_points(input_list)
print batch_output_prod
```

it gave `[[{u'maxDate': u'2016-12-31T00:00:00.000Z', u'maxValue': {u'start': 1483142400000, u'reportingDate': None, u'end': 1483142400000, u'value': 882.724527113847}, u'minValue': {u'start': 1483142400000, u'reportingDate': None, u'end': 1483142400000, u'value': 882.724527113847}, u'series': {u'itemId': 8819, u'regionId': 1215, u'sourceId': 87, u'metricId': 15530037, u'inputUnitScale': 1, u'inputUnitId': 975, u'unitId': 975, u'frequencyId': 15, u'belongsTo': {u'itemId': 8819, u'sourceId': 87, u'frequencyId': 15, u'metricId': 15530037, u'regionId': 1215}}, u'data': [[u'2016-12-31T00:00:00.000Z', u'2016-12-31T00:00:00.000Z', 882.724527113847]], u'minDate': u'2016-12-31T00:00:00.000Z'}]]`, 
instead of desired `[[{u'input_unit_scale': 1, u'region_id': 1215, u'end_date': u'2016-12-31T00:00:00.000Z', u'input_unit_id': 975, u'unit_id': 975, u'value': 882.724527113847, u'frequency_id': 15, u'item_id': 8819, u'start_date': u'2016-12-31T00:00:00.000Z', u'metric_id': 15530037}]]`, 
the reason being `get_data_points` within GroClient yields <class 'tornado.concurrent.Future'> objects, not series lists.

The fix is to apply `lib.list_of_series_to_single_series` after all asynchronously queried series lists are consolidated.  
