### PR TITLE
CLEWS-16687 Use contains endpoint for get_descendant_regions

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -286,7 +286,8 @@ class Client(object):
         return lib.get_geojson(self.access_token, self.api_host, region_id)
 
 
-    def get_descendant_regions(self, region_id, descendant_level=None, include_historical=True):
+    def get_descendant_regions(self, region_id, descendant_level=None,
+                               include_historical=True, include_details=True):
         """Look up details of all regions of the given level contained by a region.
 
         Given any region by id, get all the descendant regions that are of the specified level.
@@ -300,6 +301,10 @@ class Client(object):
         include_historical : boolean, optional
             True by default. If False is specified, regions that only exist in historical data
             (e.g. the Soviet Union) will be excluded.
+        include_details : boolean, optional
+            True by default. Will perform a lookup() on each descendant region to find name,
+            latitude, longitude, etc. If this option is set to False, only ids of descendant
+            regions will be returned, which makes execution significantly faster.
 
         Returns
         -------
@@ -322,5 +327,5 @@ class Client(object):
             See output of :meth:`~.lookup`
 
         """
-        return lib.get_descendant_regions(self.access_token, self.api_host,
-                                          region_id, descendant_level, include_historical)
+        return lib.get_descendant_regions(self.access_token, self.api_host, region_id,
+                                          descendant_level, include_historical, include_details)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -602,28 +602,27 @@ def get_descendant_regions(access_token, api_host, region_id,
                            descendant_level=False, include_historical=True, include_details=True):
     url = '/'.join(['https:', '', api_host, 'v2/regions/contains'])
     headers = {'authorization': 'Bearer ' + access_token}
-    params = {
-        'ids': [region_id]
-    }
+    params = {'ids': [region_id]}
     if descendant_level:
         params['level'] = descendant_level
     else:
         params['distance'] = -1
+
     resp = get_data(url, headers, params)
     descendant_region_ids = resp.json()['data'][str(region_id)]
 
-    # Exit early if no additional details are needed:
-    if not include_details and include_historical:
-        return [{'id': descendant_region_id}
+    # Filter out regions with the 'historical' flag set to true
+    if not include_historical:
+        descendant_region_ids = [
+            descendant_region_id for descendant_region_id in descendant_region_ids
+            if not lookup(access_token, api_host, 'regions', descendant_region_id)['historical']
+        ]
+
+    if include_details:
+        return [lookup(access_token, api_host, 'regions', descendant_region_id)
                 for descendant_region_id in descendant_region_ids]
 
-    detailed_regions = [lookup(access_token, api_host, 'regions', descendant_region_id)
-                        for descendant_region_id in descendant_region_ids]
-    if not include_historical:
-        # filter out regions with the 'historical' flag
-        return [detailed_region for detailed_region in detailed_regions
-                if not detailed_region['historical']]
-    return detailed_regions
+    return [{'id': descendant_region_id} for descendant_region_id in descendant_region_ids]
 
 
 if __name__ == '__main__':

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,3 +10,4 @@ seaborn
 scikit-learn<0.21.0  # last version to support Python 2
 scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
 tsfresh<0.13.0  # last version to support Python 2
+statsmodels<0.11.0  # Required by tsfresh. Last version to support Python 2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,11 +2,11 @@ dateparser
 dtw==1.3.3
 matplotlib
 mock
-numpy
-pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
+numpy<=v1.16.6  # last version to support python 2
+pandas>=0.20.3,!=0.24.*  # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 pytest
 pytest-cov
 seaborn
-scikit-learn
-scipy
-tsfresh
+scikit-learn<0.21.0  # last version to support Python 2
+scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
+tsfresh<0.13.0  # last version to support Python 2


### PR DESCRIPTION
Switched over get_descendant_regions to use the new `/v2/regions/contains` functionality added in v1.60 instead of recursively checking the 'contains' of each region.

Since `/v2/regions/contains` only returns ids where the old method returned entire objects, I had to add in `lookup()`s to make the output identical. So, by default, there's not an order of magnitude performance difference between the old way and the new way.

But, I added this `include_details` flag which bypasses that and does have an order of magnitude speed-up.

To test the speed difference I ran the following script:

```py
from api.client.gro_client import GroClient
import os
import time

client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])
start = time.time()
client.get_descendant_regions(1215, descendant_level=5)
end = time.time()
print('{:.2f}s'.format(end-start))
```

1. Before this change: 327.72s
2. With this change: 257.62s
3. With this change, with `include_details=False` added to the params list: 0.15s

Case 2 can be sped up in the future by batching those lookup() requests, but case 3 is immediately usable and much improved.