### PR TITLE
CLEWS-20851 Replace bare string exception

### DIFF
--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -54,7 +54,7 @@ def mock_test_units(entity_type, entity_id):
             'convType': 0
         }
     else:
-        raise '{} {} not mocked'.format(entity_type, entity_id)
+        raise Exception('{} {} not mocked'.format(entity_type, entity_id))
 
 client.lookup = MagicMock(
     side_effect=mock_test_units


### PR DESCRIPTION
Raising strings was removed in python 3, so this was getting flagged by pylint as a Python 3 incompatible line. Functionally makes no difference since:

1. this is only in a test
2. it still serves its purpose of raising an exception when it fails
3. it only gets called if a unit test is written incorrectly