### PR TITLE
CLEWS-22325 get data points (omit historical regions)

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -144,8 +144,8 @@ class Client(object):
         return lib.get_data_series(self.access_token, self.api_host, **selection)
 
 
-    def get_data_points(self, **selection):
-        return lib.get_data_points(self.access_token, self.api_host, **selection)
+    def get_data_points(self, include_historical=True, **selection):
+        return lib.get_data_points(self.access_token, self.api_host, include_historical=include_historical, **selection)
 
 
     def search(self, entity_type, search_terms):

--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -144,8 +144,8 @@ class Client(object):
         return lib.get_data_series(self.access_token, self.api_host, **selection)
 
 
-    def get_data_points(self, include_historical=True, **selection):
-        return lib.get_data_points(self.access_token, self.api_host, include_historical=include_historical, **selection)
+    def get_data_points(self, **selection):
+        return lib.get_data_points(self.access_token, self.api_host, **selection)
 
 
     def search(self, entity_type, search_terms):

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -83,12 +83,14 @@ class BatchClient(GroClient):
                         url, retry_count, e.response.error))
 
     @gen.coroutine
-    def get_data_points(self, **selection):
+    def get_data_points(self, include_historical=True, **selection):
         """Get all the data points for a given selection, which is some or all
         of: item_id, metric_id, region_id, frequency_id, source_id,
         partner_region_id. Additional arguments are allowed and ignored.
         """
-        data_points = super(BatchClient, self).get_data_points(**selection)
+        data_points = super(BatchClient, self).get_data_points(
+            include_historical=include_historical, 
+            **selection)
         raise gen.Return(data_points)
 
     def get_df(self, show_revisions=True):
@@ -102,7 +104,7 @@ class BatchClient(GroClient):
     # TODO: deprecate  the following  two methods, standardize  on one
     # approach with get_data_points and get_df
     @gen.coroutine
-    def get_data_points_generator(self, **selection):
+    def get_data_points_generator(self, include_historical=True, **selection):
         headers = {'authorization': 'Bearer ' + self.access_token}
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
@@ -110,10 +112,12 @@ class BatchClient(GroClient):
         raise gen.Return(json_decode(resp))
 
     def batch_async_get_data_points(self, batched_args, output_list=None,
-                                    map_result=None):
+                                    map_result=None, include_historical=True):
+        for args in batched_args:
+            args['include_historical'] = include_historical
         batch_async_series_list = self.batch_async_queue(
             self.get_data_points_generator, batched_args, output_list, map_result)
-        return [lib.list_of_series_to_single_series(series_list) for series_list in batch_async_series_list]
+        return [lib.list_of_series_to_single_series(series_list, False, include_historical) for series_list in batch_async_series_list]
 
     @gen.coroutine
     def async_rank_series_by_source(self, **selection):

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -104,7 +104,7 @@ class BatchClient(GroClient):
     @gen.coroutine
     def get_data_points_generator(self, **selection):
         headers = {'authorization': 'Bearer ' + self.access_token}
-        url = '/'.join(['http:', '', self.api_host, 'v2/data'])
+        url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
         resp = yield self.get_data(url, headers, params)
         raise gen.Return(json_decode(resp))

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -99,7 +99,7 @@ class GroClient(Client):
         else:
             self._data_frame = self._data_frame.merge(tmp, how='outer')
 
-    def get_data_points(self, include_historical=True, **selections):
+    def get_data_points(self, **selections):
         """Get all the data points for a given selection.
 
         https://developers.gro-intelligence.com/data-point-definition.html
@@ -209,13 +209,15 @@ class GroClient(Client):
         at_time : string, optional
             Estimate what data would have been available via Gro at a given time in the past. See
             :sample:`at-time-query-examples.ipynb` for more details.
+        include_historical : boolean, optional
+            True by default, will include historical regions that are part of your selections
 
         Returns
         -------
         list of dicts
 
         """
-        data_points = super(GroClient, self).get_data_points(include_historical=include_historical, **selections)
+        data_points = super(GroClient, self).get_data_points(**selections)
         # Apply unit conversion if a unit is specified
         if 'unit_id' in selections:
             return list(map(functools.partial(self.convert_unit,

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -99,7 +99,7 @@ class GroClient(Client):
         else:
             self._data_frame = self._data_frame.merge(tmp, how='outer')
 
-    def get_data_points(self, **selections):
+    def get_data_points(self, include_historical=True, **selections):
         """Get all the data points for a given selection.
 
         https://developers.gro-intelligence.com/data-point-definition.html
@@ -215,7 +215,7 @@ class GroClient(Client):
         list of dicts
 
         """
-        data_points = super(GroClient, self).get_data_points(**selections)
+        data_points = super(GroClient, self).get_data_points(include_historical=include_historical, **selections)
         # Apply unit conversion if a unit is specified
         if 'unit_id' in selections:
             return list(map(functools.partial(self.convert_unit,

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -491,6 +491,7 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False):
         # Only need to do this once per series, so do this outside of the list
         # comprehension and save to a variable to avoid duplicate work:
         belongs_to = camel_to_snake_dict(series.get('series', {}).get('belongsTo', {}))
+        series_metadata = series.get('series', {}).get('metadata', None)
         for point in series.get('data', []):
             formatted_point = {
                 'start_date': point[0],
@@ -513,6 +514,8 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False):
                 'frequency_id': series['series'].get('frequencyId', None)
                 # 'source_id': series['series'].get('sourceId', None), TODO: add source to output
             }
+            if series_metadata:
+                formatted_point['metadata'] = series_metadata
             if add_belongs_to:
                 # belongs_to is consistent with the series the user requested. So if an
                 # expansion happened on the server side, the user can reconstruct what

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -527,11 +527,12 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
     return output
 
 
-def get_data_points(access_token, api_host, include_historical=True, **selection):
+def get_data_points(access_token, api_host, **selection):
     headers = {'authorization': 'Bearer ' + access_token}
     url = '/'.join(['https:', '', api_host, 'v2/data'])
     params = get_data_call_params(**selection)
     resp = get_data(url, headers, params)
+    include_historical = selection.get('include_historical', True)
     return list_of_series_to_single_series(resp.json(), False, include_historical)
 
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -488,7 +488,8 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
         if not (isinstance(series, dict) and isinstance(series.get('data', []), list)):
             continue
         series_metadata = series.get('series', {}).get('metadata', {})
-        if not include_historical and series_metadata.get('includesHistoricalRegion', False):
+        if not include_historical and (series_metadata.get('includesHistoricalRegion', False) or 
+        series_metadata.get('includesHistoricalPartnerRegion', False)):
             continue
         # All the belongsTo keys are in camelCase. Convert them to snake_case.
         # Only need to do this once per series, so do this outside of the list
@@ -516,8 +517,6 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
                 'frequency_id': series['series'].get('frequencyId', None)
                 # 'source_id': series['series'].get('sourceId', None), TODO: add source to output
             }
-            if series_metadata:
-                formatted_point['metadata'] = series_metadata
             if add_belongs_to:
                 # belongs_to is consistent with the series the user requested. So if an
                 # expansion happened on the server side, the user can reconstruct what


### PR DESCRIPTION
Adding option to get_data_points function to include historical region. This will be true by default, and users can have the option to exclude from response.

get_data_points:
```
selections = {}
selections['region_id'] = 14
selections['metric_id'] = 860032
selections['item_id'] = 5074
selections['source_id'] = 14
selections['frequency_id'] = 9
client.get_data_points(include_historical=False, **selections)
```

api response flags series metadata for historical region, api client has the option to filter these