### PR TITLE
Analogous Years Modifications

### DIFF
--- a/api/client/samples/analogous_years/lib/distance_matrix.py
+++ b/api/client/samples/analogous_years/lib/distance_matrix.py
@@ -46,7 +46,7 @@ def dtw_dist_matrix(dataframe):
     return distance_matrix
 
 
-def scaled_labeled_method_distances(distance_matrix_df, initial_date, final_date, method):
+def scaled_labeled_method_distances(distance_matrix_df, initial_date, display_final_date, method):
     """
     Retrieves and scales a column of the input dataframe
     :param distance_matrix_df: A pandas dataframe
@@ -59,7 +59,7 @@ def scaled_labeled_method_distances(distance_matrix_df, initial_date, final_date
     list_of_methods = ['euclidean', 'cumulative', 'dtw', 'ts-features']
     if method.split('_')[0] not in list_of_methods:
         raise ValueError('Method of calculation unavailable')
-    column_name = initial_date + ' to ' + final_date
+    column_name = initial_date + ' to ' + display_final_date
     ranked_periods_df = pd.DataFrame(distance_matrix_df[column_name])
     scaler = MaxAbsScaler()
     ranked_periods_df.loc[:, column_name] = scaler.fit_transform(ranked_periods_df[[column_name]])

--- a/api/client/samples/analogous_years/lib/final_ranks_computation.py
+++ b/api/client/samples/analogous_years/lib/final_ranks_computation.py
@@ -9,10 +9,9 @@ import os
 import matplotlib
 matplotlib.use('agg')
 import seaborn as sns
-
+from dateutil.relativedelta import relativedelta
 import numpy as np
 import pandas as pd
-
 
 from api.client.samples.analogous_years.lib import \
     distance_matrix, \
@@ -20,33 +19,91 @@ from api.client.samples.analogous_years.lib import \
     get_transform_data
 
 
-def common_start_date(client, data_series, provided_start_date=None):
+def date_utils(client, data_series_list, initial_date, final_date,
+               provided_start_date=None):
     """Computes the earliest available start date from which all gro-data_series have data"""
     logger = client.get_logger()
     start_date_list = []
     if provided_start_date:
         start_date_list.append(provided_start_date)
-    for i in range(len(data_series)):
-        dates = client.get_data_points(**data_series[i])
-        if len(dates) == 0:
-            msg = "No data found for the following gro-data_series - {}".format(data_series[i])
-            logger.warning(msg)
-            raise Exception
-        else:
-            start_date_list.append(dates[0]['start_date'])
-    start_date = max(start_date_list)
-    for i in range(len(data_series)):
-        data_series[i]['start_date'] = start_date
-    return {'data_series': data_series, 'start_date': start_date}
+    end_date_list = []
+
+    for data_series in data_series_list:
+        min_local_start_date = client.get_data_series(**data_series)[0]['start_date']
+        max_local_end_date = client.get_data_series(**data_series)[0]['end_date']
+        # choose the best start/end date if there are subregions
+        for sub_data_series in client.get_data_series(**data_series):
+            if sub_data_series['start_date'] < min_local_start_date:
+                min_local_start_date = sub_data_series['start_date']
+            if sub_data_series['end_date'] > max_local_end_date:
+                max_local_end_date = sub_data_series['end_date']
+        data_series['end_date'] = max_local_end_date
+        start_date_list.append(min_local_start_date)
+        end_date_list.append(max_local_end_date)
+
+    # Adding global start date to the data series
+    global_start_date = max(start_date_list)
+    for data_series in data_series_list:
+        data_series['start_date'] = global_start_date
+
+    # Computing the display initial and final date for all the series combined
+    display_final_date = data_series_list[0]['end_date']
+    display_initial_date = (pd.to_datetime(data_series_list[0]['end_date']) - relativedelta(
+        pd.to_datetime(final_date),
+        pd.to_datetime(initial_date))).strftime('%Y-%m-%dT%H:%M:%S.000Z')
+    for data_series in data_series_list:
+        if data_series['end_date'] < final_date:
+            logger.info('Data is available until {}'.format(data_series['end_date']))
+            data_series['final_date'] = data_series['end_date']
+        if display_final_date < data_series['end_date']:
+            display_final_date = data_series['end_date']
+            display_initial_date = (
+                    pd.to_datetime(data_series['final_date']) - relativedelta(
+                pd.to_datetime(final_date),
+                pd.to_datetime(initial_date))).strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+        if display_final_date < data_series['final_date']:
+            display_final_date = data_series['final_date']
+            display_initial_date = (pd.to_datetime(data_series['final_date']) - relativedelta(
+                pd.to_datetime(final_date),
+                pd.to_datetime(initial_date))).strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+    for data_series in data_series_list:
+        data_series['initial_date'] = display_initial_date
+    logger.info('Computing analogous years between {} and {} for the available data'.format(
+        display_initial_date, display_final_date))
+    return data_series_list, display_final_date, display_initial_date
 
 
-def enso_data(start_date):
+# def common_start_date(client, data_series, provided_start_date=None):
+#     """Computes the earliest available start date from which all gro-data_series have data"""
+#     logger = client.get_logger()
+#     start_date_list = []
+#     if provided_start_date:
+#         start_date_list.append(provided_start_date)
+#     for i in range(len(data_series)):
+#         dates = client.get_data_points(**data_series[i])
+#         if len(dates) == 0:
+#             msg = "No data found for the following gro-data_series - {}".format(data_series[i])
+#             logger.warning(msg)
+#             raise Exception
+#         else:
+#             start_date_list.append(dates[0]['start_date'])
+#     start_date = max(start_date_list)
+#     for i in range(len(data_series)):
+#         data_series[i]['start_date'] = start_date
+#     return {'data_series': data_series, 'start_date': start_date}
+
+
+def enso_data(start_date, initial_date, display_final_date):
     enso_data_series = {'metric_id': 15851977,
                         'item_id': 13495,
                         'region_id': 0,
                         'source_id': 124,
                         'start_date': start_date,
-                        'frequency_id': 6}
+                        'frequency_id': 6,
+                        'initial_date': initial_date,
+                        'final_date': display_final_date}
     return enso_data_series
 
 
@@ -58,13 +115,13 @@ def get_file_name(client, data_series_list, initial_date, final_date):
         key_words.append(client.lookup('items', data_series_list[i]['item_id'])['name'])
     key_words.append(initial_date)
     key_words.append(final_date)
-    logger.info("\n Computing analogous years' ranks in {} with respect to {} between {} and {} \n".
+    logger.info("Computing analogous years' ranks in {} with respect to {} between {} and {}".
                 format(key_words[0], key_words[1:-2], initial_date, final_date))
     combined_name = '_'.join(key_words)
     return combined_name
 
 
-def time_series(client, data_series, initial_date, final_date):
+def time_series(client, data_series, initial_date, final_date, display_final_date):
     """
     retrieves a sub-time series of a time series associated with a gro data_series
     :param client: GroClient
@@ -86,7 +143,8 @@ def time_series(client, data_series, initial_date, final_date):
     try:
         ts = get_transform_data.extract_time_periods_by_dates(consolidated_data,
                                                               initial_date,
-                                                              final_date)
+                                                              final_date,
+                                                              display_final_date)
         return ts
     except Exception as e:
         message = ('Please check availability of data for {}'.format(client.lookup(
@@ -116,7 +174,8 @@ def ay_dtw(timeseries):
     return distance_matrix.dtw_dist_matrix(pivot_time_series)
 
 
-def ranked_df_dictionary(client, data_series, initial_date, final_date, item, methods_list):
+def ranked_df_dictionary(client, data_series, initial_date, final_date, display_final_date, item,
+                         methods_list):
     """
     Returns a dictionary whose keys are given by a 'method_item' and values are the dataframes
     of distances computed for that item using that method. Example: key: cumulative_Rainfall
@@ -128,7 +187,7 @@ def ranked_df_dictionary(client, data_series, initial_date, final_date, item, me
     :param methods_list: a sublist of ['cumulative', 'euclidean', 'ts-features', 'dtw']
     :return: Dictionary of dataframes
     """
-    ts = time_series(client, data_series, initial_date, final_date)
+    ts = time_series(client, data_series, initial_date, final_date, display_final_date)
     dictionary_of_methods = {'cumulative_' + item: ay_cumulative,
                              'euclidean_' + item: ay_euclidean,
                              'dtw_' + item: ay_dtw,
@@ -136,8 +195,10 @@ def ranked_df_dictionary(client, data_series, initial_date, final_date, item, me
     ranked_dfs = {}
     for key, value in dictionary_of_methods.items():
         if key.split('_')[0] in methods_list:
+            initial_date = initial_date.replace(' ', 'T').split('T')[0]
+            display_final_date = display_final_date.replace(' ', 'T').split('T')[0]
             ranked_dfs[key] = distance_matrix.scaled_labeled_method_distances(
-                value(ts), initial_date, final_date, key)
+                value(ts), initial_date, display_final_date, key)
     return ranked_dfs
 
 
@@ -185,23 +246,33 @@ def analogous_years(client, data_series_list, initial_date, final_date,
     The dataframe contains integer values (ranks)
     """
     combined_items_distances = None
-    data_series_list = common_start_date(client, data_series_list, provided_start_date)[
-        'data_series']
-    start_date = common_start_date(client, data_series_list, provided_start_date)['start_date']
+    data_series_list, display_final_date, display_initial_date = \
+        date_utils(
+            client, data_series_list, initial_date, final_date, provided_start_date)
+    start_date = data_series_list[0]['start_date']
+    # data_series_list = common_start_date(client, data_series_list, provided_start_date)[
+    #    'data_series']
+    # start_date = common_start_date(client, data_series_list, provided_start_date)['start_date']
+
     if not weights:
         weights = [1] * len(data_series_list)
     if enso:
-        data_series_list.append(enso_data(start_date))
+        data_series_list.append(enso_data(start_date, initial_date, display_final_date))
         if enso_weight:
             weights.append(enso_weight)
         else:
             weights.append(1)
+
     for i in range(len(data_series_list)):
         gro_item = client.lookup('items', data_series_list[i]['item_id'])['name']
+
+        actual_initial_date = data_series_list[i].pop('initial_date')
+        actual_final_date = data_series_list[i].pop('final_date')
+
         combined_methods_distances_df = combined_methods_distances(
             ranked_df_dictionary(
-                client, data_series_list[i], initial_date,
-                final_date, gro_item, methods_list))
+                client, data_series_list[i], actual_initial_date,
+                actual_final_date, display_final_date, gro_item, methods_list))
         numpy_combined_methods_distances = combined_methods_distances_df.values
         if combined_items_distances is None:
             combined_items_distances = np.zeros(numpy_combined_methods_distances.shape)

--- a/api/client/samples/analogous_years/run_analogous_years.py
+++ b/api/client/samples/analogous_years/run_analogous_years.py
@@ -7,6 +7,7 @@ from api.client.gro_client import GroClient
 
 from api.client.samples.analogous_years.lib import final_ranks_computation
 
+
 def str2bool(v):
     if isinstance(v, bool):
         return v
@@ -114,12 +115,25 @@ def main():
     client = GroClient(API_HOST, args.groapi_token)
     data_series_list = get_data_series_list(args.region_id, args.item_ids, args.metric_ids,
                                             args.source_ids, args.frequency_ids, client=client)
-    # series_list, display_final_date, display_initial_date = \
-    #     get_df_experiment.common_start_date(
+    # data_series_list, display_final_date, display_initial_date = \
+    #     final_ranks_computation.date_utils(
     #         client, data_series_list, args.initial_date, args.final_date, args.start_date)
+    # for series in data_series_list:
+    #     series.pop('start_date')
+    #     series.pop('end_date')
+    data_series_list_w_start_end_dates = final_ranks_computation.start_end_date_list(
+        client, data_series_list, args.start_date)[0]
+
+    display_initial_date, display_final_date = \
+        final_ranks_computation.display_initial_final_date(client,
+                                                           data_series_list_w_start_end_dates,
+                                                           args.initial_date,
+                                                           args.final_date)[1:]
+
     folder_name = final_ranks_computation.get_file_name(client, data_series_list,
-                                                        initial_date=args.initial_date,
-                                                        final_date=args.final_date)
+                                                        display_initial_date,
+                                                        display_final_date,
+                                                        args.ENSO)
     result = final_ranks_computation.analogous_years(
         client, data_series_list, args.initial_date, args.final_date,
         methods_list=args.methods, all_ranks=args.all_ranks,

--- a/api/client/samples/analogous_years/run_analogous_years.py
+++ b/api/client/samples/analogous_years/run_analogous_years.py
@@ -7,7 +7,6 @@ from api.client.gro_client import GroClient
 
 from api.client.samples.analogous_years.lib import final_ranks_computation
 
-
 def str2bool(v):
     if isinstance(v, bool):
         return v
@@ -115,6 +114,9 @@ def main():
     client = GroClient(API_HOST, args.groapi_token)
     data_series_list = get_data_series_list(args.region_id, args.item_ids, args.metric_ids,
                                             args.source_ids, args.frequency_ids, client=client)
+    # series_list, display_final_date, display_initial_date = \
+    #     get_df_experiment.common_start_date(
+    #         client, data_series_list, args.initial_date, args.final_date, args.start_date)
     folder_name = final_ranks_computation.get_file_name(client, data_series_list,
                                                         initial_date=args.initial_date,
                                                         final_date=args.final_date)


### PR DESCRIPTION
Modifying analogous years to make it more suitable for Gro email alerts. The modifications will include - 
1. Calculating analogous years for the latest date available if no data is available for today.
2. When computing the analogous years for multiple series, finding the best dates for computation of analogous years for all the series.