### PR TITLE
CLEWS-24615: API client errors handling

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -244,7 +244,7 @@ def get_data(url, headers, params=None, logger=None):
             logger.warning('Redirecting {} to {}'.format(params, new_params), extra=log_record)
             params = new_params
         elif data.status_code in [400, 401, 404, 500]:
-            raise APIError(data, retry_count, url)
+            break
         else:
             logger.error('{}'.format(data), extra=log_record)
     raise APIError(data, retry_count, url)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -244,14 +244,10 @@ def get_data(url, headers, params=None, logger=None):
             logger.warning('Redirecting {} to {}'.format(params, new_params), extra=log_record)
             params = new_params
         elif data.status_code in [400, 401, 404, 500]:
-            try:
-                raise APIError(data, retry_count, url)
-            except APIError as error:
-                return error
+            raise APIError(data, retry_count, url)
         else:
             logger.error('{}'.format(data), extra=log_record)
-    raise Exception('Giving up on {} after {} tries: {}.'.format(
-        url, retry_count, data))
+    raise APIError(data, retry_count, url)
 
 
 @memoize(maxsize=None)


### PR DESCRIPTION
Description
- These are the errors that are handled by the added exception **400, 401, 404, 500**
- The current implementation returns a response as shown below 👇 

> _API call failed with the error message:_
> Giving up on https://api.gro-intelligence.com/sample_unit/ after 1 tries:

- Seeing as it is difficult to parse the message ☝️ the error message will include the following info in the response body

1. Status Code
2. Retry Count
3. Response
4. Message
5. Url
