### PR TITLE
CLEWS-25000 Update BatchClient mapResult to allow custom accumulator

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -64,11 +64,10 @@ class GroClient(Client):
             data_series = self._data_series_queue.pop()
             if show_revisions:
                 data_series['show_revisions'] = True
-            self.add_points_to_df(
-                0, data_series, self.get_data_points(**data_series))
+            self.add_points_to_df(0, data_series, self.get_data_points(**data_series))
         return self._data_frame
 
-    def add_points_to_df(self, index, data_series, data_points):
+    def add_points_to_df(self, index, data_series, data_points, *args):
         """Internal function used by get_df to add individual series to the
         frame.
 

--- a/api/client/samples/analogous_years/requirements.txt
+++ b/api/client/samples/analogous_years/requirements.txt
@@ -1,9 +1,10 @@
 dateparser
 dtw==1.3.3
-numpy
+numpy<=v1.16.6  # last version to support python 2
 pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 seaborn
-scikit-learn
-scipy
-tsfresh
+scikit-learn<0.21.0  # last version to support Python 2
+scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
+tsfresh<0.13.0  # last version to support Python 2
+statsmodels<0.11.0  # Required by tsfresh. Last version to support Python 2
 matplotlib

--- a/api/client/samples/similar_regions/requirements.txt
+++ b/api/client/samples/similar_regions/requirements.txt
@@ -1,0 +1,4 @@
+dateparser
+datetime
+scikit-learn
+tqdm

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,13 +1,5 @@
-dateparser
-dtw==1.3.3
-matplotlib
-mock
-numpy<=v1.16.6  # last version to support python 2
-pandas>=0.20.3,!=0.24.*  # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 pytest
 pytest-cov
-seaborn
-scikit-learn<0.21.0  # last version to support Python 2
-scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
-tsfresh<0.13.0  # last version to support Python 2
-statsmodels<0.11.0  # Required by tsfresh. Last version to support Python 2
+mock
+-r api/client/samples/analogous_years/requirements.txt
+-r api/client/samples/similar_regions/requirements.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,14 @@
+dateparser
+datetime
+dtw==1.3.3
+matplotlib
+mock
+numpy<=v1.16.6  # last version to support python 2
+pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 pytest
 pytest-cov
-mock
--r api/client/samples/analogous_years/requirements.txt
--r api/client/samples/similar_regions/requirements.txt
+scikit-learn<0.21.0  # last version to support Python 2
+scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
+seaborn
+statsmodels<0.11.0  # Required by tsfresh. Last version to support Python 2
+tsfresh<0.13.0  # last version to support Python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ pandas
 python-dateutil
 pytz
 requests
-tornado>=5.1
 unicodecsv
 urllib3


### PR DESCRIPTION
Two things being addressed here:

1. The response getting passed to map_response was the unformatted point before it goes through the `list_of_series_to_single_series()` function. This reverses that order so map_result can operate on a single_series point.
2. map_result didn't allow accumulators other than lists of lists. This allows things like dataframes to be passed in.

Test script, tested on python 3 and 2.7.16:

```py
from api.client.batch_client import BatchClient
from api.client.gro_client import DATA_POINTS_UNIQUE_COLS
import os
import pandas as pd

def main():
    client = BatchClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])

    input_list = [
        {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'frequency_id': 9, 'source_id': 2},
        {'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'frequency_id': 9, 'source_id': 2}
    ]

    output_list = []

    def map_response(inputIndex, inputObject, response, output_list):
        output_list += response
        return output_list

    batch_output = client.batch_async_get_data_points(input_list,
                                                      output_list=output_list,
                                                      map_result=map_response)
    print('batch output rows: {}'.format(len(batch_output)))

    def map_response_df(inputIndex, inputObject, response, merged_df):
        df = pd.DataFrame(data=response).dropna(how='all')
        if df.empty:
            return merged_df
        df['region_id'] = df['region_id'].astype(int)
        df['start_date'] = pd.to_datetime(df['start_date'])
        df['end_date'] = pd.to_datetime(df['end_date'])
        if inputObject.get('show_revisions', False):
            df['reporting_date'] = pd.to_datetime(df['reporting_date'])
        else:
            df = df.drop('reporting_date', axis=1)
        if merged_df.empty:
            merged_df = df
            merged_df.set_index([col for col in DATA_POINTS_UNIQUE_COLS if col in df.columns])
        else:
            merged_df = merged_df.merge(df, how='outer')
        return merged_df

    merged_df = client.batch_async_get_data_points(input_list, map_result=map_response_df,
                                                   output_list=pd.DataFrame())
    print('Merged df: {}'.format(merged_df))

main()
```