### PR TITLE
Update BatchClient get_df and rank_series_by_source to use new map function

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -226,7 +226,7 @@ class Client(object):
         return lib.lookup_belongs(self.access_token, self.api_host, entity_type, entity_id)
 
 
-    def rank_series_by_source(self, series_list):
+    def rank_series_by_source(self, selections_list):
         """Given a list of series selections, for each unique combination excluding source, expand
         to all available sources and return them in ranked order. The order corresponds to how well
         that source covers the selection (metrics, items, regions, and time range and frequency).
@@ -242,8 +242,7 @@ class Client(object):
             The input series_list, expanded out to each possible source, ordered by coverage.
 
         """
-        return lib.rank_series_by_source(self.access_token, self.api_host,
-                                         series_list)
+        return lib.rank_series_by_source(self.access_token, self.api_host, selections_list)
 
 
     def get_geo_centre(self, region_id):

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -99,8 +99,9 @@ class BatchClient(GroClient):
         if show_revisions:
             for data_series in self._data_series_queue:
                 data_series['show_revisions'] = True
-        return self.batch_async_queue(self.get_data_points, self._data_series_queue,
-                                      self._data_frame, self.add_points_to_df)
+        self.batch_async_queue(self.get_data_points, self._data_series_queue, None,
+                               self.add_points_to_df)
+        return self._data_frame
 
     # TODO: deprecate  the following  two methods, standardize  on one
     # approach with get_data_points and get_df

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -99,9 +99,8 @@ class BatchClient(GroClient):
         if show_revisions:
             for data_series in self._data_series_queue:
                 data_series['show_revisions'] = True
-        self.batch_async_queue(self.get_data_points, self._data_series_queue, [],
-                               self.add_points_to_df)
-        return self._data_frame
+        return self.batch_async_queue(self.get_data_points, self._data_series_queue,
+                                      self._data_frame, self.add_points_to_df)
 
     # TODO: deprecate  the following  two methods, standardize  on one
     # approach with get_data_points and get_df
@@ -111,7 +110,11 @@ class BatchClient(GroClient):
         url = '/'.join(['https:', '', self.api_host, 'v2/data'])
         params = lib.get_data_call_params(**selection)
         resp = yield self.get_data(url, headers, params)
-        raise gen.Return(json_decode(resp))
+        list_of_series_points = json_decode(resp)
+        include_historical = selection.get('include_historical', True)
+        points = lib.list_of_series_to_single_series(list_of_series_points, False,
+                                                     include_historical)
+        raise gen.Return(points)
 
     def batch_async_get_data_points(self, batched_args, output_list=None,
                                     map_result=None):
@@ -181,13 +184,21 @@ class BatchClient(GroClient):
                                       map_result)
 
     @gen.coroutine
-    def async_rank_series_by_source(self, **selection):
+    def async_rank_series_by_source(self, *selections_list):
         """Get all sources, in ranked order, for a given selection."""
-        response = super(BatchClient, self).rank_series_by_source(**selection)
-        raise gen.Return([r for r in response])
+        response = super(BatchClient, self).rank_series_by_source(selections_list)
+        raise gen.Return(list(response))
 
     def batch_async_rank_series_by_source(self, batched_args,
                                           output_list=None, map_result=None):
+        """Perform multiple rank_series_by_source requests asynchronously.
+
+        Parameters
+        ----------
+        batched_args : list of lists of dicts
+            See :meth:`~.rank_series_by_source` `selections_list`. A list of those lists.
+
+        """
         return self.batch_async_queue(self.async_rank_series_by_source, batched_args,
                                       output_list, map_result)
 
@@ -245,12 +256,14 @@ class BatchClient(GroClient):
                 idx, item = q.get().result()
                 self._logger.debug('Doing work on {}'.format(idx))
                 if type(item) is dict:
+                    # Assume that dict types should be unpacked as kwargs
                     result = yield func(**item)
-                else:
+                elif type(item) is list:
+                    # Assume that list types should be unpacked as positional args
                     result = yield func(*item)
-                include_historical = item.get('include_historical', True)
-                points = lib.list_of_series_to_single_series(result, False, include_historical)
-                output_data['result'] = map_result(idx, item, points, output_data['result'])
+                else:
+                    result = yield func(item)
+                output_data['result'] = map_result(idx, item, result, output_data['result'])
                 self._logger.debug('Done with {}'.format(idx))
                 q.task_done()
 

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -97,7 +97,6 @@ class GroClient(Client):
                                         if col in tmp.columns])
         else:
             self._data_frame = self._data_frame.merge(tmp, how='outer')
-        return self._data_frame
 
     def get_data_points(self, **selections):
         """Get all the data points for a given selection.

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -64,18 +64,17 @@ class GroClient(Client):
             data_series = self._data_series_queue.pop()
             if show_revisions:
                 data_series['show_revisions'] = True
-            self.add_points_to_df(0, data_series, self.get_data_points(**data_series))
+            self.add_points_to_df(None, data_series, self.get_data_points(**data_series))
         return self._data_frame
 
     def add_points_to_df(self, index, data_series, data_points, *args):
-        """Internal function used by get_df to add individual series to the
-        frame.
+        """Add the given datapoints to a pandas dataframe.
 
         Parameters:
         -----------
-        index: unused
-        data_series: dict
-        data_points: list of dict
+        index : unused
+        data_series : dict
+        data_points : list of dicts
 
         """
         tmp = pandas.DataFrame(data=data_points)
@@ -91,12 +90,14 @@ class GroClient(Client):
             tmp.start_date = pandas.to_datetime(tmp.start_date)
         if 'reporting_date' in tmp.columns:
             tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
+
         if self._data_frame.empty:
             self._data_frame = tmp
             self._data_frame.set_index([col for col in DATA_POINTS_UNIQUE_COLS
                                         if col in tmp.columns])
         else:
             self._data_frame = self._data_frame.merge(tmp, how='outer')
+        return self._data_frame
 
     def get_data_points(self, **selections):
         """Get all the data points for a given selection.


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/gro-intelligence/api-client/pull/167

Two main changes:

1. `list_of_series_to_single_series()` is moved to `get_data_points_generator()`. Previous PR erroneously treated `batch_async_queue()` like it was only being used for `batch_async_get_data_points()`. Removed that assumption so `batch_async_rank_series_by_source()` and `get_df()` can also use that function.
2. `async_rank_series_by_source()` was originally unpacking `selection`, which is inconsistent with how I expected that function to behave. Added a docstring for the input type I expect - @sempervirescent please let me know if I misunderstood. List of the un-batched function's inputs, list of the un-batched function's outputs, like how `batch_async_get_data_points()` is. Note `rank_series_by_source` normally takes a list of dicts.

Test cases:

```py
>>> from api.client.batch_client import BatchClient
>>> import os
>>> client = BatchClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])

>>> client.add_single_data_series({'metric_id': 15610005, 'region_id': 1215, 'frequency_id': 15, 'source_id': 81, 'partner_region_id': 0, 'item_id': 274})
Added {'metric_id': 15610005, 'region_id': 1215, 'frequency_id': 15, 'source_id': 81, 'partner_region_id': 0, 'item_id': 274}
>>> client.get_df()
Queued 1 requests in 1.621246337890625e-05
INFO:api.client.lib:Queued 1 requests in 1.621246337890625e-05
                      start_date                  end_date    value  unit_id  input_unit_id  input_unit_scale            reporting_date  metric_id  item_id  region_id  partner_region_id  frequency_id  source_id
0      1972-03-01 00:00:00+00:00 1972-03-31 00:00:00+00:00  20523.0      225            225                 1 1972-01-03 00:00:00+00:00   15610005      274       1215                  0            15         81
1      1972-03-01 00:00:00+00:00 1972-03-31 00:00:00+00:00  20242.0      225            225                 1 1972-01-04 00:00:00+00:00   15610005      274       1215                  0            15         81
2      1972-03-01 00:00:00+00:00 1972-03-31 00:00:00+00:00  19748.0      225            225                 1 1972-01-05 00:00:00+00:00   15610005      274       1215                  0            15         81
3      1972-03-01 00:00:00+00:00 1972-03-31 00:00:00+00:00  10336.0      225            225                 1 1972-01-06 00:00:00+00:00   15610005      274       1215                  0            15         81
4      1972-03-01 00:00:00+00:00 1972-03-31 00:00:00+00:00  19356.0      225            225                 1 1972-01-07 00:00:00+00:00   15610005      274       1215                  0            15         81

>>> client.batch_async_rank_series_by_source([[{'metric_id': 860032, 'item_id': 274, 'region_id': 1215}], [{'metric_id': 860032, 'item_id': 270, 'region_id': 1215}]])
Queued 2 requests in 3.981590270996094e-05
INFO:api.client.lib:Queued 2 requests in 3.981590270996094e-05
[[{'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 25}, {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 2}, {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 14}, {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 24}, {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 106}, {'metric_id': 860032, 'item_id': 274, 'region_id': 1215, 'source_id': 19}], [{'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'source_id': 25}, {'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'source_id': 14}, {'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'source_id': 2}, {'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'source_id': 106}, {'metric_id': 860032, 'item_id': 270, 'region_id': 1215, 'source_id': 19}]]
>>>
```