### PR TITLE
CLEWS-25750 CLEWS-25400 Retry BatchClient on other types of errors

### DIFF
--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -116,7 +116,10 @@ class BatchClient(GroClient):
                                                  hasattr(e.response, 'error')) else e
                 log_request(start_time, retry_count, error_msg, status_code)
                 if status_code in [429, 500, 503, 504]:
-                    time.sleep(2 ** retry_count)  # Exponential backoff before retrying.
+                    # First retry is immediate.
+                    # After that, exponential backoff before retrying.
+                    if retry_count > 1:
+                        time.sleep(2 ** retry_count)
                     continue
                 elif status_code in [400, 401, 402, 404]:
                     break  # Do not retry. Go right to raising an Exception.

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -72,13 +72,14 @@ class BatchClient(GroClient):
 
         Assigns headers and builds in retries and logging.
         """
-        retry_count = 0
         self._logger.debug(url)
 
         # append version info
         headers.update(lib.get_version_info())
 
-        while retry_count < cfg.MAX_RETRIES:
+        # Initialize to -1 so first attempt will be retry 0
+        retry_count = -1
+        while retry_count <= cfg.MAX_RETRIES:
             retry_count += 1
             start_time = time.time()
             http_request = HTTPRequest('{url}?{params}'.format(url=url, params=urlencode(params)),
@@ -118,7 +119,7 @@ class BatchClient(GroClient):
                 if status_code in [429, 500, 503, 504]:
                     # First retry is immediate.
                     # After that, exponential backoff before retrying.
-                    if retry_count > 1:
+                    if retry_count > 0:
                         time.sleep(2 ** retry_count)
                     continue
                 elif status_code in [400, 401, 402, 404]:

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -12,13 +12,11 @@ except ImportError:
 from tornado import gen
 from tornado.escape import json_decode
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
-import socket
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
 from api.client import cfg, lib
 from api.client.gro_client import GroClient
 from api.client.lib import APIError
-import random
 
 
 class BatchClient(GroClient):
@@ -69,13 +67,6 @@ class BatchClient(GroClient):
                 try:
                     response = yield self._http_client.fetch(http_request)
                     status_code = response.code
-                    random_error = random.choice(range(1, 10))
-                    if random_error == 1:
-                        raise socket.gaierror()
-                    elif random_error == 2:
-                        raise HTTPError(500, 'Internal server error')
-                    elif random_error == 3:
-                        raise HTTPError(206, 'Partial content')
                 except HTTPError as e:
                     # Catch non-200 codes that aren't actually errors
                     status_code = e.code if hasattr(e, 'code') else None

--- a/api/client/batch_client.py
+++ b/api/client/batch_client.py
@@ -38,8 +38,8 @@ class BatchError(APIError):
         except Exception:
             # If the error message can't be parsed, fall back to a generic "giving up" message.
             self.message = 'Giving up on {} after {} {}: {}'.format(self.url, self.retry_count,
-                                                                    'try' if self.retry_count == 1
-                                                                    else 'tries', response)
+                                                                    'retry' if self.retry_count == 1
+                                                                    else 'retries', response)
 
 
 class BatchClient(GroClient):


### PR DESCRIPTION
Things resolved in this PR:

* Was only catching HTTPError codes before (non-200 status code responses). Now we're catching other exceptions, like broken sockets, and retrying those.
* Previously when one of the above non-HTTPError exceptions would occur, the Tornado event loop would never complete. Now, we're always either raising a response or an error.
* Now the BatchErrors will be returned by default, so the user can handle them at the end or via map_result.

Testing script:

```py
selections = [
    {'metric_id': 570001, 'item_id': 274, 'region_id': r['id'], 'source_id': 25, 'frequency_id': 9}
    for r in client.get_descendant_regions(1215, descendant_level=4, include_details=False)
]

try:
    for e in client.batch_async_get_data_points(selections):
        print(e.message)
except Exception as e:
    print('EXCEPTION CAUGHT:', e)

try:
    def ignore_nulls(idx, query, response, accumulator):
        accumulator[idx] = None if isinstance(response, Exception) else response
        return accumulator
    for result in client.batch_async_get_data_points(selections, map_result=ignore_nulls):
        print(result)
except Exception as e:
    print('EXCEPTION CAUGHT:', e)
```

In the first loop you get BatchError objects, and their message is printed. So it appears like:

```py
...
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
Internal Server Error: An internal server error occurred
Internal Server Error: An internal server error occurred
Internal Server Error: An internal server error occurred
Internal Server Error: An internal server error occurred
Internal Server Error: An internal server error occurred
...
```

In the second block, map_result is converting the 500 errors into Nones, so it looks like this:

```py
...
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
None
None
None
None
None
...
```

Or, if you want to exit execution immediately when one of the batched queries is returning an error, you can raise it in the map_result function to break the IOLoop:

```py
try:
    def raise_exception(idx, query, response, accumulator):
        if isinstance(response, Exception):
            print('{} {} response is an Exception: [{}] {}'.format(response.url, response.params, response.status_code, response.message))
            raise response
        accumulator[idx] = response
        return accumulator

    for result in client.batch_async_get_data_points(selections, map_result=raise_exception):
        print(result)
except Exception as e:
    print('EXCEPTION CAUGHT:', e)
```

which looks like

```py
HTTP 500: Internal Server Error
WARNING:api.client.lib:HTTP 500: Internal Server Error
http://localhost:5000/v2/data {'metricId': 570001, 'itemId': 274, 'regionId': 13051, 'sourceId': 25, 'frequencyId': 9, 'responseType': 'list_of_series'} response is an Exception: [500] Internal Server Error: An internal server error occurred
EXCEPTION CAUGHT: Operation timed out after None seconds
```