### PR TITLE
handle case where data cannot be normalized return absolute weights

### DIFF
--- a/api/client/crop_model.py
+++ b/api/client/crop_model.py
@@ -67,7 +67,7 @@ class CropModel(GroClient):
         self.get_logger().debug('Means = {}'.format(
             list(zip([region['name'] for region in regions], means))))
         # Normalize into weights
-        total = math.fsum([x for x in means if not math.isnan(x)])
+        total = numpy.nansum(means)
         if not numpy.isclose(total, 0.0):
             return [float(mean)/total for mean in means]
         self.get_logger().warning(

--- a/api/client/crop_model.py
+++ b/api/client/crop_model.py
@@ -3,6 +3,7 @@ from builtins import map
 from builtins import zip
 from datetime import datetime
 import math
+import numpy
 import pandas
 from api.client.gro_client import GroClient
 
@@ -63,11 +64,16 @@ class CropModel(GroClient):
                       (df['metric_id'] == entities['metric_id']) &
                       (df['region_id'] == region['id'])]['value'].mean(skipna=True)
         means = list(map(mapper, regions))
-        self._logger.debug('Means = {}'.format(
+        self.get_logger().debug('Means = {}'.format(
             list(zip([region['name'] for region in regions], means))))
         # Normalize into weights
         total = math.fsum([x for x in means if not math.isnan(x)])
-        return [float(mean)/total for mean in means]
+        if not numpy.isclose(total, 0.0):
+            return [float(mean)/total for mean in means]
+        self.get_logger().warning(
+            'Cannot normalize {} {} data.'.format(crop_name, metric_name))
+        return means
+
 
     def compute_crop_weighted_series(self, weighting_crop_name, weighting_metric_name,
                                      item_name, metric_name, regions):


### PR DESCRIPTION
Avoids a division by zero failure when the total is 0.

We do not enforce any assumption on the given series, but in basic
cases where the weighting series is non-negative, total=0 happens when
the data is all 0 or missing so returning 0 weights is most convenient
in applications where there are multiple sets of weights.