### PR TITLE
CLEWS-17178: optimize GroClient data retrieval for dataframe

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -42,7 +42,7 @@ class GroClient(Client):
     def __init__(self, api_host, access_token):
         super(GroClient, self).__init__(api_host, access_token)
         self._logger = lib.get_default_logger()
-        self._data_series_list = []  # all that have been added
+        self._data_series_list = set()  # all that have been added
         self._data_series_queue = []  # added but not loaded in data frame
         self._data_frame = pandas.DataFrame()
 
@@ -301,9 +301,13 @@ class GroClient(Client):
         None
 
         """
-        self._data_series_list.append(data_series)
-        self._data_series_queue.append(data_series)
-        self._logger.info("Added {}".format(data_series))
+        series_hash = frozenset(data_series.items())
+        if series_hash not in self._data_series_list:
+            self._data_series_list.add(series_hash)
+            self._data_series_queue.append(data_series)
+            self._logger.info("Added {}".format(data_series))
+        else:
+            self._logger.debug("Already added: {}".format(data_series))
         return
 
     def find_data_series(self, **kwargs):

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -104,7 +104,7 @@ class GroClient(Client):
         if self._data_frame.empty:
             self._data_frame = tmp
         else:
-            self._data_frame = self._data_frame.merge(tmp, how='outer')
+            self._data_frame = pandas.concat([self._data_frame, tmp])
 
     def get_data_points(self, **selections):
         """Get all the data points for a given selection.


### PR DESCRIPTION
When a user  adds the same series repeatedly currently we just do it naively i.e. don’t try to deduplicate.  This is inefficient in scenarios where the user is rerunning the same functions many times (e.g. developing a model iteratively in a notebook for example). At the same time, in most use cases, the underlying data does not change within a single run of a model so we don't need  incremental updates (though that might be useful in the future in conjuction with load/save to disk for longer term data state).

This change deduplicates and only retreives each series once. 
