### PR TITLE
CLEWS-26695 Top N method

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -362,7 +362,7 @@ class Client(object):
         return lib.get_available_timefrequency(self.access_token, self.api_host,
                                                **selection)
 
-    def get_top(self, entity_type, n=5, **selection):
+    def get_top(self, entity_type, num_results=5, **selection):
         """Find the data series with the highest cumulative value for the given time range.
 
         Examples::
@@ -375,15 +375,15 @@ class Client(object):
                         start_date='2014-01-01', end_date='2014-12-31')
 
             # To get the United States' top 15 exports in the decade of 2010-2019:
-            >>> get_top('items', n=15, metric_id=20032, region_id=1215, frequency_id=9, source_id=2,
-                        start_date='2010-01-01', end_date='2019-12-31')
+            >>> get_top('items', num_results=15, metric_id=20032, region_id=1215, frequency_id=9,
+                        source_id=2, start_date='2010-01-01', end_date='2019-12-31')
 
         Parameters
         ----------
         entity_type : { 'items', 'regions' }
             The entity type to rank, all other selections being the same. Only items and regions
             are rankable at this time.
-        n : integer, optional
+        num_results : integer, optional
             How many data series to rank. Top 5 by default.
         metric_id : integer
         item_id : integer
@@ -417,4 +417,4 @@ class Client(object):
             value the series are ranked by. You may then use the results to call
             :meth:`~.get_data_points` to get the individual time series points.
         """
-        return lib.get_top(self.access_token, self.api_host, entity_type, n, **selection)
+        return lib.get_top(self.access_token, self.api_host, entity_type, num_results, **selection)

--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -351,8 +351,8 @@ class Client(object):
                  [{
                     'startDate': '2000-02-18T00:00:00.000Z',
                     'frequencyId': 3,
-                     'endDate': '2020-03-12T00:00:00.000Z',
-                     'name': '8-day'
+                    'endDate': '2020-03-12T00:00:00.000Z',
+                    'name': '8-day'
                   }, {
                     'startDate': '2019-09-02T00:00:00.000Z',
                     'frequencyId': 1,
@@ -361,3 +361,60 @@ class Client(object):
         """
         return lib.get_available_timefrequency(self.access_token, self.api_host,
                                                **selection)
+
+    def get_top(self, entity_type, n=5, **selection):
+        """Find the data series with the highest cumulative value for the given time range.
+
+        Examples::
+
+            # To get FAO's top 5 corn-producing countries of all time:
+            >>> get_top('regions', metric_id=860032, item_id=274, frequency_id=9, source_id=2)
+
+            # To get FAO's top 5 corn-producing countries of 2014:
+            >>> get_top('regions', metric_id=860032, item_id=274, frequency_id=9, source_id=2,
+                        start_date='2014-01-01', end_date='2014-12-31')
+
+            # To get the United States' top 15 exports in the decade of 2010-2019:
+            >>> get_top('items', n=15, metric_id=20032, region_id=1215, frequency_id=9, source_id=2,
+                        start_date='2010-01-01', end_date='2019-12-31')
+
+        Parameters
+        ----------
+        entity_type : { 'items', 'regions' }
+            The entity type to rank, all other selections being the same. Only items and regions
+            are rankable at this time.
+        n : integer, optional
+            How many data series to rank. Top 5 by default.
+        metric_id : integer
+        item_id : integer
+            Required if requesting top regions. Disallowed if requesting top items.
+        region_id : integer
+            Required if requesting top items. Disallowed if requesting top regions.
+        partner_region_id : integer, optional
+        frequency_id : integer
+        source_id : integer
+        start_date : string, optional
+            If not provided, the cumulative value used for ranking will include data points as far
+            back as the source provides.
+        end_date : string, optional
+
+        Returns
+        -------
+        list of dicts
+
+            Example::
+
+                [
+                    {'metricId': 860032, 'itemId': 274, 'regionId': 1215, 'frequencyId': 9,
+                     'sourceId': 2, 'value': 400, 'unitId': 14},
+                    {'metricId': 860032, 'itemId': 274, 'regionId': 1215, 'frequencyId': 9,
+                     'sourceId': 2, 'value': 395, 'unitId': 14},
+                    {'metricId': 860032, 'itemId': 274, 'regionId': 1215, 'frequencyId': 9,
+                     'sourceId': 2, 'value': 12, 'unitId': 14},
+                ]
+
+            Along with the series attributes, value and unit are also given for the total cumulative
+            value the series are ranked by. You may then use the results to call
+            :meth:`~.get_data_points` to get the individual time series points.
+        """
+        return lib.get_top(self.access_token, self.api_host, entity_type, n, **selection)

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -416,6 +416,18 @@ def get_data_series(access_token, api_host, **selection):
         raise Exception(resp.text)
 
 
+def get_top(access_token, api_host, entity_type, n=5, **selection):
+    url = '/'.join(['https:', '', api_host, 'v2/top/{}'.format(entity_type)])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = get_params_from_selection(**selection)
+    params['n'] = n
+    resp = get_data(url, headers, params)
+    try:
+        return resp.json()
+    except KeyError:
+        raise Exception(resp.text)
+
+
 def make_key(key):
     if key not in ('startDate', 'endDate'):
         return key + 's'

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -416,11 +416,11 @@ def get_data_series(access_token, api_host, **selection):
         raise Exception(resp.text)
 
 
-def get_top(access_token, api_host, entity_type, n=5, **selection):
+def get_top(access_token, api_host, entity_type, num_results=5, **selection):
     url = '/'.join(['https:', '', api_host, 'v2/top/{}'.format(entity_type)])
     headers = {'authorization': 'Bearer ' + access_token}
     params = get_params_from_selection(**selection)
-    params['n'] = n
+    params['n'] = num_results
     resp = get_data(url, headers, params)
     try:
         return resp.json()

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -1,6 +1,8 @@
 import mock
 
 from api.client import lib
+from requests import Response
+import json
 import platform
 from pkg_resources import get_distribution
 
@@ -339,3 +341,16 @@ def test_descendant_regions(mock_requests_get, lookup_mocked):
 
     assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 14, include_historical=False,
                                       include_details=False) == [{'id': 2}]
+
+
+@mock.patch('requests.get')
+def test_get_top(mock_requests_get):
+    mock_response = [
+        {'itemId': 274, 'value': 13175206696, 'unitId': 14},
+        {'itemId': 574, 'value': 13175206878, 'unitId': 14},
+        {'itemId': 7193, 'value': 13175206343, 'unitId': 14}
+    ]
+    mock_requests_get.return_value.json.return_value = mock_response
+    mock_requests_get.return_value.status_code = 200
+    assert lib.get_top(MOCK_TOKEN, MOCK_HOST, 'items', metric_id=14) == mock_response
+    assert lib.get_top(MOCK_TOKEN, MOCK_HOST, 'items', n=3, metric_id=14) == mock_response

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -1,8 +1,6 @@
 import mock
 
 from api.client import lib
-from requests import Response
-import json
 import platform
 from pkg_resources import get_distribution
 

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -351,4 +351,4 @@ def test_get_top(mock_requests_get):
     mock_requests_get.return_value.json.return_value = mock_response
     mock_requests_get.return_value.status_code = 200
     assert lib.get_top(MOCK_TOKEN, MOCK_HOST, 'items', metric_id=14) == mock_response
-    assert lib.get_top(MOCK_TOKEN, MOCK_HOST, 'items', n=3, metric_id=14) == mock_response
+    assert lib.get_top(MOCK_TOKEN, MOCK_HOST, 'items', num_results=3, metric_id=14) == mock_response


### PR DESCRIPTION
I added several usage examples to the `Client.get_top()` docstring, highlighting:

1. the minimal case: full time range, default n
2. top in a single year
3. a specific time range, with n>5

PTAL at the docstring in particular for documentation clarity.