### PR TITLE
CLEWS-19840 numpy fix

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -242,6 +242,10 @@ def list_available(access_token, api_host, selected_entities):
 
 
 def lookup(access_token, api_host, entity_type, entity_ids):
+    try:  # Convert iterable types like numpy arrays or tuples into plain lists
+        entity_ids = list(entity_ids)
+    except TypeError:  # Convert anything else, like strings or numpy integers, into plain integers
+        entity_ids = int(entity_ids)
     url = '/'.join(['https:', '', api_host, 'v2', entity_type])
     headers = {'authorization': 'Bearer ' + access_token}
     params = {'ids': str(entity_ids)}

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -1,4 +1,5 @@
 import mock
+import numpy as np
 
 from api.client import lib
 import platform
@@ -110,6 +111,25 @@ def test_multiple_lookups(mock_requests_get):
         '67890': {'id': 67890, 'name': 'Eggplant', 'contains': [], 'belongsTo': [12345]}
     }
     assert lib.lookup(MOCK_TOKEN, MOCK_HOST, 'items', [12345, 67890]) == expected_return
+
+
+@mock.patch('requests.get')
+def test_lookup_with_numpy(mock_requests_get):
+    api_response = {
+        'data': {
+            '12345': {'id': 12345, 'name': 'Vegetables', 'contains': [67890], 'belongsTo': []},
+            '67890': {'id': 67890, 'name': 'Eggplant', 'contains': [], 'belongsTo': [12345]}
+        }
+    }
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
+    expected_return = {
+        '12345': {'id': 12345, 'name': 'Vegetables', 'contains': [67890], 'belongsTo': []},
+        '67890': {'id': 67890, 'name': 'Eggplant', 'contains': [], 'belongsTo': [12345]}
+    }
+    assert lib.lookup(MOCK_TOKEN, MOCK_HOST, 'items', np.array([12345, 67890])) == expected_return
+
+    assert lib.lookup(MOCK_TOKEN, MOCK_HOST, 'items',
+                      np.array([12345])[0]) == expected_return['12345']
 
 
 @mock.patch('requests.get')


### PR DESCRIPTION
Because `lookup()` is checking whether `entity_ids` is an `int` or anything else and numpy.integer is *not* an int, lookup was returning the list-like output (a dict of dicts) instead of the int-like output (a single dict).

In this PR, I'm using `list()` and `int()` to convert things like numpy arrays and numpy ints into their expected types.

See the added test cases. Before, `np.array()` as a list-like type worked fine because it fell into the `else` category, but `np.array()[0]` did not work because it also fell into the `else` despite being int-like. Note that `np.array([1])` (a numpy array with a single element) can be cast into an int

```py
>>> type(int(np.array([1])))
<class 'int'>
```

and so that's why I did list() first and then int() as the fall-back. Order matters. So here a single-element numpy array will still be treated as a list.