### PR TITLE
CLEWS-17178 Add index names to get_df

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-from api.client import cfg, lib, Client
-from api.client.constants import DATA_SERIES_UNIQUE_TYPES_ID, ENTITY_KEY_TO_TYPE
 from builtins import str
 from builtins import zip
 from random import random
@@ -9,8 +7,13 @@ import functools
 import getpass
 import itertools
 import os
-import pandas
 import sys
+
+from api.client import cfg, lib, Client
+from api.client.constants import DATA_SERIES_UNIQUE_TYPES_ID, ENTITY_KEY_TO_TYPE
+from api.client.utils import intersect
+
+import pandas
 import unicodecsv
 
 
@@ -62,10 +65,8 @@ class GroClient(Client):
                 data_series['show_revisions'] = True
             self.add_points_to_df(None, data_series, self.get_data_points(**data_series))
         if index_by_series:
-            indexed_df = self._data_frame.set_index([
-                type_id for type_id in DATA_SERIES_UNIQUE_TYPES_ID
-                if type_id in self._data_frame.columns
-            ])
+            indexed_df = self._data_frame.set_index(intersect(DATA_SERIES_UNIQUE_TYPES_ID,
+                                                              self._data_frame.columns))
             indexed_df.index.set_names(DATA_SERIES_UNIQUE_TYPES_ID, inplace=True)
             return indexed_df.sort_index()
         return self._data_frame

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -67,7 +67,7 @@ class GroClient(Client):
                 if type_id in self._data_frame.columns
             ])
             indexed_df.index.set_names(DATA_SERIES_UNIQUE_TYPES_ID, inplace=True)
-            return indexed_df
+            return indexed_df.sort_index()
         return self._data_frame
 
     def add_points_to_df(self, index, data_series, data_points, *args):

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -62,9 +62,12 @@ class GroClient(Client):
                 data_series['show_revisions'] = True
             self.add_points_to_df(None, data_series, self.get_data_points(**data_series))
         if index_by_series:
-            return self._data_frame.set_index([c for c in filter(
-                lambda col: col in self._data_frame.columns,
-                DATA_SERIES_UNIQUE_TYPES_ID)])
+            indexed_df = self._data_frame.set_index([
+                type_id for type_id in DATA_SERIES_UNIQUE_TYPES_ID
+                if type_id in self._data_frame.columns
+            ])
+            indexed_df.index.set_names(DATA_SERIES_UNIQUE_TYPES_ID, inplace=True)
+            return indexed_df
         return self._data_frame
 
     def add_points_to_df(self, index, data_series, data_points, *args):

--- a/api/client/utils.py
+++ b/api/client/utils.py
@@ -76,6 +76,34 @@ def dict_reformat_keys(obj, format_func):
     return {format_func(key): value for key, value in obj.items()}
 
 
+def intersect(lhs_list, rhs_list):
+    """Return the common elements of two lists
+
+    >>> intersect([1,2,3], [4,5,6])
+    []
+
+    >>> intersect([1,2,3], [4,5,6,2])
+    [2]
+
+    >>> intersect([1,2,3], [1,2,3])
+    [1, 2, 3]
+
+    Parameters
+    ----------
+    lhs_list : list
+        A list of some type that can be compared using `in`
+    rhs_list : list
+        A list of some type that can be compared using `in`
+
+    Returns
+    -------
+    list
+        A list of common elements
+
+    """
+    return list(filter(lambda elem: elem in rhs_list, lhs_list))
+
+
 if __name__ == '__main__':
     # To run doctests:
     # $ python utils.py -v


### PR DESCRIPTION
Follow-up to https://github.com/gro-intelligence/api-client/pull/194

Now, you can use `df.index.names` to take an index value and re-associate it back to metric_id/item_id/etc.:

```py
df = client.get_df(index_by_series=True)

for series in df.index.unique():
    series_name = ' '.join([client.lookup(ENTITY_KEY_TO_TYPE[type_id], series[i])['name']
                            for i, type_id in enumerate(df.index.names)])
    print(series_name)
```

Before, you would have needed to know which order the series attributes are indexed in.