### PR TITLE
add option to make plot work with calendar year and market year

### DIFF
--- a/api/client/samples/crop_models/brazil_soybeans.ipynb
+++ b/api/client/samples/crop_models/brazil_soybeans.ipynb
@@ -135,7 +135,7 @@
     "yield_df.set_index('end_date')\n",
     "fig, axes = plt.subplots(1, 1)\n",
     "for source_id, group in yield_df.groupby('source_id'):\n",
-    "    group.plot(x='end_date', y='value', ax=axes, \n",
+    "    group.plot(x='end_date', y='value', ax=axes, x_compat=True,\n",
     "               label=model.lookup('sources', source_id)['name'])\n",
     "plt.ylabel(\"Yield (t/ha)\")\n",
     "plt.show()"


### PR DESCRIPTION
`ValueError: Incompatible frequency conversion` 

is caused by the fact that some of the series changed from calendar year to market years. 

Fix is to set x_compat=True in plot().
https://github.com/pandas-dev/pandas/issues/7772#issuecomment-49505711