### PR TITLE
CLEWS-25139 Python 2 class syntax

### DIFF
--- a/api/client/batch_client_test.py
+++ b/api/client/batch_client_test.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from api.client.batch_client import BatchClient
+
+MOCK_HOST = 'pytest.groclient.url'
+MOCK_TOKEN = 'pytest.groclient.token'
+
+class BatchClientTests(TestCase):
+    def test_initialization(self):
+        client = BatchClient(MOCK_HOST, MOCK_TOKEN)
+        self.assertIsInstance(client, BatchClient)

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -21,7 +21,7 @@ API_HOST = 'api.gro-intelligence.com'
 OUTPUT_FILENAME = 'gro_client_output.csv'
 
 
-class GroClient:
+class GroClient(object):
     """API client with stateful authentication for lib functions and extra convenience methods."""
 
     def __init__(self, api_host, access_token):


### PR DESCRIPTION
Caused by https://github.com/gro-intelligence/api-client/pull/205/files#diff-603e79178b8e522d0e366a9fca477b24R24

GroClient needs to subclass `(object)` explicitly for BatchClient to use the `super()` function in the way we expect in Python 2. The "new-style" class is the default in Python 3, so the object subclassing is implicit and not needed. https://www.python.org/doc/newstyle/

Nothing in the unit tests was initializing BatchClient, so I added a failing test that would have caught this.