### PR TITLE
CLEWS-27227: memoization on lookups

### DIFF
--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -68,9 +68,18 @@ def test_list_available_snake_to_camel(mock_requests_get):
 
 @mock.patch('requests.get')
 def test_single_lookup(mock_requests_get):
-    api_response = {'data': {'12345': {'id': 12345, 'name': 'Test', 'contains': []}}}
+    api_response = {
+        'data': {
+            '12345': {
+                'id': 12345,
+                'name': 'Vegetables',
+                'contains': [67890],
+                'belongsTo': []
+            }
+        }
+    }
     initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
-    expected_return = {'id': 12345, 'name': 'Test', 'contains': []}
+    expected_return = {'id': 12345, 'name': 'Vegetables', 'contains': [67890], 'belongsTo': []}
     assert lib.lookup(MOCK_TOKEN, MOCK_HOST, 'items', 12345) == expected_return
 
 


### PR DESCRIPTION
Separate out `lookup_single` and `lookup_batch` from `lookup` so that `lookup_single` can take advantage of memoization.

Before https://github.com/gro-intelligence/api-client/pull/161/files#diff-7ed38827a2c4e58f0dd776f8639dc95cL299 we had memoization on the `lookup()` function so that if you called it many times within the same script, it wouldn't duplicate requests.

It was removed when requesting lists of entities was added as a feature because lists can't be used as hashable inputs to memoization. By splitting up lookup by single id and lookup by list of ids, we can still take advantage of memoization on the former.

Future work: implement memoization such that that only requests the difference between requested entities and already-cached entities