### PR TITLE
Add GroClient.get_top() to API reference page

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,6 +46,8 @@ Advanced Exploration
 
 .. automethod:: api.client.gro_client.GroClient.get_available_timefrequency
 
+.. automethod:: api.client.gro_client.GroClient.get_top
+
 ============
 Pandas Utils
 ============


### PR DESCRIPTION
The `GroClient.get_top()` method was added in https://github.com/gro-intelligence/api-client/pull/196 along with a docstring for it. This PR publishes it on https://developers.gro-intelligence.com/api.html

See here: https://developers.gro-intelligence.com/CLEWS-26695-doc/api.html#api.client.gro_client.GroClient.get_top