### PR TITLE
feat: add show_meta_data as a get_data_points option

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -431,64 +431,7 @@ def get_available_timefrequency(access_token, api_host, **series):
 
 
 def list_of_series_to_single_series(series_list, add_belongs_to=False, include_historical=True):
-    """Convert list_of_series format from API back into the familiar single_series output format.
-
-    >>> list_of_series_to_single_series([{
-    ...     'series': { 'metricId': 1, 'itemId': 2, 'regionId': 3, 'unitId': 4, 'inputUnitId': 5,
-    ...                 'belongsTo': { 'itemId': 22 }
-    ...     },
-    ...     'data': [
-    ...         ['2001-01-01', '2001-12-31', 123],
-    ...         ['2002-01-01', '2002-12-31', 123, '2012-01-01'],
-    ...         ['2003-01-01', '2003-12-31', 123, None, 15, {}]
-    ...     ]
-    ... }], True) == [
-    ...   { 'start_date': '2001-01-01',
-    ...     'end_date': '2001-12-31',
-    ...     'value': 123,
-    ...     'unit_id': 4,
-    ...     'metadata': {},
-    ...     'input_unit_id': 4,
-    ...     'input_unit_scale': 1,
-    ...     'reporting_date': None,
-    ...     'metric_id': 1,
-    ...     'item_id': 2,
-    ...     'region_id': 3,
-    ...     'partner_region_id': 0,
-    ...     'frequency_id': None,
-    ...     'belongs_to': { 'item_id': 22 } },
-    ...   { 'start_date': '2002-01-01',
-    ...     'end_date': '2002-12-31',
-    ...     'value': 123,
-    ...     'unit_id': 4,
-    ...     'metadata': {},
-    ...     'input_unit_id': 4,
-    ...     'input_unit_scale': 1,
-    ...     'reporting_date': '2012-01-01',
-    ...     'metric_id': 1,
-    ...     'item_id': 2,
-    ...     'region_id': 3,
-    ...     'partner_region_id': 0,
-    ...     'frequency_id': None,
-    ...     'belongs_to': { 'item_id': 22 } },
-    ...   { 'start_date': '2003-01-01',
-    ...     'end_date': '2003-12-31',
-    ...     'value': 123,
-    ...     'unit_id': 15,
-    ...     'metadata': {},
-    ...     'input_unit_id': 15,
-    ...     'input_unit_scale': 1,
-    ...     'reporting_date': None,
-    ...     'metric_id': 1,
-    ...     'item_id': 2,
-    ...     'region_id': 3,
-    ...     'partner_region_id': 0,
-    ...     'frequency_id': None,
-    ...     'belongs_to': { 'item_id': 22 } },
-    ... ]
-    True
-
-    """
+    """Convert list_of_series format from API back into the familiar single_series output format."""
     if not isinstance(series_list, list):
         # If the output is an error or None or something else that's not a list, just propagate
         return series_list

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -334,7 +334,7 @@ def get_data_call_params(**selection):
     end_date : string, optional
     show_revisions : boolean, optional
     insert_null : boolean, optional
-    show_meta_data : boolean, optional
+    show_metadata : boolean, optional
     at_time : string, optional
 
     Returns
@@ -345,8 +345,10 @@ def get_data_call_params(**selection):
     """
     params = get_params_from_selection(**selection)
     for key, value in list(selection.items()):
-        if key in ('start_date', 'end_date', 'show_revisions', 'insert_null', 'show_meta_data', 'at_time'):
+        if key in ('start_date', 'end_date', 'show_revisions', 'insert_null', 'at_time'):
             params[str_snake_to_camel(key)] = value
+        elif key == 'show_metadata':
+            params['show_meta_data'] = value
     params['responseType'] = 'list_of_series'
     return params
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -334,6 +334,7 @@ def get_data_call_params(**selection):
     end_date : string, optional
     show_revisions : boolean, optional
     insert_null : boolean, optional
+    show_meta_data : boolean, optional
     at_time : string, optional
 
     Returns
@@ -344,7 +345,7 @@ def get_data_call_params(**selection):
     """
     params = get_params_from_selection(**selection)
     for key, value in list(selection.items()):
-        if key in ('start_date', 'end_date', 'show_revisions', 'insert_null', 'at_time'):
+        if key in ('start_date', 'end_date', 'show_revisions', 'insert_null', 'show_meta_data', 'at_time'):
             params[str_snake_to_camel(key)] = value
     params['responseType'] = 'list_of_series'
     return params
@@ -507,7 +508,8 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
                 'value': point[2],
                 # list_of_series has unit_id in the series attributes currently. Does
                 # not allow for mixed units in the same series
-                'unit_id': series['series'].get('unitId', None),
+                'unit_id': point[4] if len(point) > 4 else None,
+                'metadata': point[5] if len(point) > 5 else {},
                 # input_unit_id and input_unit_scale are deprecated but provided for backwards
                 # compatibility. unit_id should be used instead.
                 'input_unit_id': series['series'].get('unitId', None),

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -447,6 +447,7 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
     ...     'end_date': '2001-12-31',
     ...     'value': 123,
     ...     'unit_id': 4,
+    ...     'metadata': {},
     ...     'input_unit_id': 4,
     ...     'input_unit_scale': 1,
     ...     'reporting_date': None,
@@ -460,6 +461,7 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
     ...     'end_date': '2002-12-31',
     ...     'value': 123,
     ...     'unit_id': 4,
+    ...     'metadata': {},
     ...     'input_unit_id': 4,
     ...     'input_unit_scale': 1,
     ...     'reporting_date': '2012-01-01',
@@ -473,6 +475,7 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
     ...     'end_date': '2003-12-31',
     ...     'value': 123,
     ...     'unit_id': 15,
+    ...     'metadata': {},
     ...     'input_unit_id': 15,
     ...     'input_unit_scale': 1,
     ...     'reporting_date': None,
@@ -481,7 +484,7 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
     ...     'region_id': 3,
     ...     'partner_region_id': 0,
     ...     'frequency_id': None,
-    ...     'belongs_to': { 'item_id': 22 } }
+    ...     'belongs_to': { 'item_id': 22 } },
     ... ]
     True
 

--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -345,10 +345,10 @@ def get_data_call_params(**selection):
     """
     params = get_params_from_selection(**selection)
     for key, value in list(selection.items()):
+        if key == 'show_metadata':
+            params[str_snake_to_camel('show_meta_data')] = value
         if key in ('start_date', 'end_date', 'show_revisions', 'insert_null', 'at_time'):
             params[str_snake_to_camel(key)] = value
-        elif key == 'show_metadata':
-            params['show_meta_data'] = value
     params['responseType'] = 'list_of_series'
     return params
 

--- a/api/client/lib_test.py
+++ b/api/client/lib_test.py
@@ -160,6 +160,93 @@ def test_get_data_points(mock_requests_get):
     assert lib.get_data_points(MOCK_TOKEN, MOCK_HOST, **selection_dict) == single_series_format_data
 
 
+def test_list_of_series_to_single_series():
+    assert lib.list_of_series_to_single_series([{
+        'series': {
+            'metricId': 1,
+            'itemId': 2,
+            'regionId': 3,
+            'unitId': 4,
+            'inputUnitId': 5,
+            'belongsTo': {'itemId': 22},
+            'metadata': {'includesHistoricalRegion': True}
+        },
+        'data': [
+            ['2001-01-01', '2001-12-31', 123],
+            ['2002-01-01', '2002-12-31', 123, '2012-01-01'],
+            ['2003-01-01', '2003-12-31', 123, None, 15, {'confInterval': 2}]
+        ]
+    }], add_belongs_to=True) == [
+        {'start_date': '2001-01-01',
+         'end_date': '2001-12-31',
+         'value': 123,
+         'unit_id': 4,
+         'metadata': {},
+         'input_unit_id': 4,
+         'input_unit_scale': 1,
+         'reporting_date': None,
+         'metric_id': 1,
+         'item_id': 2,
+         'region_id': 3,
+         'partner_region_id': 0,
+         'frequency_id': None,
+         'belongs_to': {'item_id': 22}},
+        {'start_date': '2002-01-01',
+         'end_date': '2002-12-31',
+         'value': 123,
+         'unit_id': 4,
+         'metadata': {},
+         'input_unit_id': 4,
+         'input_unit_scale': 1,
+         'reporting_date': '2012-01-01',
+         'metric_id': 1,
+         'item_id': 2,
+         'region_id': 3,
+         'partner_region_id': 0,
+         'frequency_id': None,
+         'belongs_to': {'item_id': 22}},
+        {'start_date': '2003-01-01',
+         'end_date': '2003-12-31',
+         'value': 123,
+         'unit_id': 15,
+         'metadata': {'confInterval': 2},
+         'input_unit_id': 15,
+         'input_unit_scale': 1,
+         'reporting_date': None,
+         'metric_id': 1,
+         'item_id': 2,
+         'region_id': 3,
+         'partner_region_id': 0,
+         'frequency_id': None,
+         'belongs_to': {'item_id': 22}},
+    ]
+
+    # test the add_belongs_to kwarg:
+    assert 'belongs_to' in lib.list_of_series_to_single_series([{
+        'series': {'unitId': 4, 'belongsTo': {'itemId': 22}},
+        'data': [['2001-01-01', '2001-12-31', 123]]
+    }], add_belongs_to=True)[0]
+
+    assert 'belongs_to' not in lib.list_of_series_to_single_series([{
+        'series': {'unitId': 4, 'belongsTo': {'itemId': 22}},
+        'data': [['2001-01-01', '2001-12-31', 123]]
+    }], add_belongs_to=False)[0]
+
+    # test the include_historical kwarg:
+    assert len(lib.list_of_series_to_single_series([{
+        'series': {'unitId': 4, 'belongsTo': {'itemId': 22}, 'metadata': {'includesHistoricalRegion': True}},
+        'data': [['2001-01-01', '2001-12-31', 123]]
+    }], include_historical=False)) == 0
+
+    assert len(lib.list_of_series_to_single_series([{
+        'series': {'unitId': 4, 'belongsTo': {'itemId': 22}, 'metadata': {'includesHistoricalRegion': True}},
+        'data': [['2001-01-01', '2001-12-31', 123]]
+    }], include_historical=True)) == 1
+
+    # test invalid input propagation
+    assert lib.list_of_series_to_single_series('test input') == 'test input'
+
+
 @mock.patch('requests.get')
 def test_search(mock_requests_get):
     mock_data = ['obj1', 'obj2', 'obj3']


### PR DESCRIPTION
Example usage:

```py
client.get_data_points(metric_id=170037, item_id=274, region_id=1215, frequency_id=9, source_id=32, show_meta_data=True)
```

currently outputs like:

```py
[{'start_date': '2011-01-01T00:00:00.000Z',
  'end_date': '2011-12-31T00:00:00.000Z',
  'value': 154.060641178363,
  'unit_id': 284,
  'metadata': {'comment': 'this is a simulation produced on 2019-10-31',
   'conf_interval': 2.482173975513856,
   'ecdf_absolute': 0.7653246855967729,
   'confInterval': 2.482173975513856},
  ...}, ...]
```

TBD:

- [ ] clean up duplication of camel and snake case confidence intervals
- [x] resolve underscore inconsistency between `show_meta_data` flag name and `metadata` output key name
- [x] doesn't work with get_df currently for the same reason as https://github.com/gro-intelligence/api-client/pull/147. The metadata's unhashable. Instead of filtering it out, I'd like to extract it into separate columns in the dataframe. More useful