### PR TITLE
Update batch_async_get_data_points test to use point unit

### DIFF
--- a/api/client/batch_client_test.py
+++ b/api/client/batch_client_test.py
@@ -16,55 +16,14 @@ from tornado.ioloop import IOLoop
 
 from api.client.batch_client import BatchClient, BatchError
 from api.client.utils import str_camel_to_snake
+from api.client.mock_data import (
+    mock_list_of_series_points,
+    mock_data_series,
+    mock_error_selection,
+)
 
-MOCK_HOST = 'pytest.groclient.url'
-MOCK_TOKEN = 'pytest.groclient.token'
-
-mock_list_of_series_points = [
-    {
-        'series': {
-            'metricId': 860032, 'itemId': 274, 'regionId': 1215,
-            'partnerRegionId': 0, 'frequencyId': 9, 'sourceId': 2,
-            'unitId': 14,
-            'belongsTo': {
-                'metricId': 860032,
-                'itemId': 274,
-                'regionId': 1215,
-                'frequencyId': 9,
-                'sourceId': 2
-            }
-        }, 'data': [
-            ['2017-01-01T00:00:00.000Z', '2017-12-31T00:00:00.000Z', 40891, None, 14, {}],
-            ['2018-01-01T00:00:00.000Z', '2018-12-31T00:00:00.000Z', 56789, '2019-03-14T00:00:00.000Z', 10, {}],
-        ]
-    }
-]
-
-mock_data_series = [
-    {
-        'metric_id': 860032,  # TODO: add names
-        'item_id': 274,
-        'region_id': 1215,
-        'partner_region_id': 0,
-        'frequency_id': 9,
-        'source_id': 2
-    }, {
-        'metric_id': 860032,  # TODO: add names
-        'item_id': 274,
-        'region_id': 1216,
-        'partner_region_id': 0,
-        'frequency_id': 9,
-        'source_id': 2
-    }
-]
-
-ERROR_SELECTION = {
-    'metric_id': 1,
-    'item_id': -15,
-    'region_id': 3,
-    'frequency_id': 4,
-    'source_id': 5
-}
+MOCK_HOST = "pytest.groclient.url"
+MOCK_TOKEN = "pytest.groclient.token"
 
 
 def mock_rank_series_by_source(access_token, api_host, selections_list):
@@ -76,20 +35,29 @@ def mock_tornado_fetch(request):
     future = Future()
     query_params = {
         str_camel_to_snake(key): value
-        for key, value in
-        [query_param.split('=')
-         for query_param in request.url.split('?')[1].split('&')]
+        for key, value in [
+            query_param.split("=")
+            for query_param in request.url.split("?")[1].split("&")
+        ]
     }
-    if int(query_params.get('item_id', 0)) < 0:
-        raise HTTPError(400, 'Negative item ids are not allowed', request)
+    if int(query_params.get("item_id", 0)) < 0:
+        raise HTTPError(400, "Negative item ids are not allowed", request)
     else:
-        response = HTTPResponse(request, 200, buffer=StringIO(json.dumps(mock_list_of_series_points)))
+        response = HTTPResponse(
+            request, 200, buffer=StringIO(json.dumps(mock_list_of_series_points))
+        )
     future.set_result(response)
     return future
 
 
-@patch('api.client.lib.rank_series_by_source', MagicMock(side_effect=mock_rank_series_by_source))
-@patch('tornado.httpclient.AsyncHTTPClient.fetch', MagicMock(side_effect=mock_tornado_fetch))
+@patch(
+    "api.client.lib.rank_series_by_source",
+    MagicMock(side_effect=mock_rank_series_by_source),
+)
+@patch(
+    "tornado.httpclient.AsyncHTTPClient.fetch",
+    MagicMock(side_effect=mock_tornado_fetch),
+)
 class GroClientTests(TestCase):
     def setUp(self):
         self.client = BatchClient(MOCK_HOST, MOCK_TOKEN)
@@ -99,54 +67,65 @@ class GroClientTests(TestCase):
         IOLoop.clear_current()
 
     def test_batch_async_get_data_points(self):
-        data_points = self.client.batch_async_get_data_points([
-            {
-                'metric_id': 1,
-                'item_id': 2,
-                'region_id': 3,
-                'frequency_id': 4,
-                'source_id': 5
-            }, {
-                'metric_id': 6,
-                'item_id': 7,
-                'region_id': 8,
-                'frequency_id': 9,
-                'source_id': 10,
-                'insert_nulls': True
-            }
-        ])
-        self.assertEqual(data_points[0][0]['start_date'], '2017-01-01T00:00:00.000Z')
-        self.assertEqual(data_points[0][0]['end_date'], '2017-12-31T00:00:00.000Z')
-        self.assertEqual(data_points[0][0]['value'], 40891)
-        self.assertEqual(data_points[0][0]['unit_id'], 14)
-        self.assertEqual(data_points[0][0]['reporting_date'], None)
-        self.assertEqual(data_points[0][1]['start_date'], '2018-01-01T00:00:00.000Z')
-        self.assertEqual(data_points[0][1]['end_date'], '2018-12-31T00:00:00.000Z')
-        self.assertEqual(data_points[0][1]['value'], 56789)
-        self.assertEqual(data_points[0][1]['unit_id'], 10)
-        self.assertEqual(data_points[0][1]['reporting_date'], '2019-03-14T00:00:00.000Z')
+        data_points = self.client.batch_async_get_data_points(
+            [
+                {
+                    "metric_id": 1,
+                    "item_id": 2,
+                    "region_id": 3,
+                    "frequency_id": 4,
+                    "source_id": 5,
+                },
+                {
+                    "metric_id": 6,
+                    "item_id": 7,
+                    "region_id": 8,
+                    "frequency_id": 9,
+                    "source_id": 10,
+                    "insert_nulls": True,
+                },
+            ]
+        )
+        self.assertEqual(data_points[0][0]["start_date"], "2017-01-01T00:00:00.000Z")
+        self.assertEqual(data_points[0][0]["end_date"], "2017-12-31T00:00:00.000Z")
+        self.assertEqual(data_points[0][0]["value"], 40891)
+        self.assertEqual(data_points[0][0]["unit_id"], 14)
+        self.assertEqual(data_points[0][0]["reporting_date"], None)
+        self.assertEqual(data_points[0][1]["start_date"], "2018-01-01T00:00:00.000Z")
+        self.assertEqual(data_points[0][1]["end_date"], "2018-12-31T00:00:00.000Z")
+        self.assertEqual(data_points[0][1]["value"], 56789)
+        self.assertEqual(data_points[0][1]["unit_id"], 10)
+        self.assertEqual(
+            data_points[0][1]["reporting_date"], "2019-03-14T00:00:00.000Z"
+        )
 
     def test_batch_async_get_data_points_map_function(self):
-
         def sum_results(inputIndex, inputObject, response, summation):
             for point in response:
-                summation += point['value']
+                summation += point["value"]
             return summation
 
         summation = self.client.batch_async_get_data_points(
-            [{'metric_id': 1, 'item_id': 2, 'region_id': 3, 'frequency_id': 4, 'source_id': 5}],
+            [
+                {
+                    "metric_id": 1,
+                    "item_id": 2,
+                    "region_id": 3,
+                    "frequency_id": 4,
+                    "source_id": 5,
+                }
+            ],
             output_list=0,
-            map_result=sum_results
+            map_result=sum_results,
         )
 
         self.assertEqual(summation, 97680)
 
     def test_batch_async_get_data_points_bad_request_error(self):
-        responses = self.client.batch_async_get_data_points([ERROR_SELECTION])
+        responses = self.client.batch_async_get_data_points([mock_error_selection])
         self.assertTrue(isinstance(responses[0], BatchError))
 
     def test_batch_async_get_data_points_map_errors(self):
-
         def raise_exception(idx, query, response, accumulator):
             if isinstance(response, Exception):
                 raise response
@@ -154,21 +133,24 @@ class GroClientTests(TestCase):
             return accumulator
 
         with self.assertRaises(Exception):
-            self.client.batch_async_get_data_points([ERROR_SELECTION],
-                                                    map_result=raise_exception)
+            self.client.batch_async_get_data_points(
+                [mock_error_selection], map_result=raise_exception
+            )
 
     def test_get_df(self):
-        self.client.add_single_data_series({
-            'metric_id': 1,
-            'item_id': 2,
-            'region_id': 3,
-            'frequency_id': 4,
-            'source_id': 5
-        })
+        self.client.add_single_data_series(
+            {
+                "metric_id": 1,
+                "item_id": 2,
+                "region_id": 3,
+                "frequency_id": 4,
+                "source_id": 5,
+            }
+        )
         df = self.client.get_df()
-        self.assertEqual(df.iloc[0]['start_date'].date(), date(2017, 1, 1))
-        self.assertEqual(df.iloc[0]['end_date'].date(), date(2017, 12, 31))
-        self.assertEqual(df.iloc[0]['value'], 40891)
+        self.assertEqual(df.iloc[0]["start_date"].date(), date(2017, 1, 1))
+        self.assertEqual(df.iloc[0]["end_date"].date(), date(2017, 12, 31))
+        self.assertEqual(df.iloc[0]["value"], 40891)
 
     def test_batch_async_rank_series_by_source(self):
         list_of_ranked_series_lists = self.client.batch_async_rank_series_by_source(
@@ -180,5 +162,5 @@ class GroClientTests(TestCase):
             # Not necessarily true, but true given the mock_rank_series_by_source() function:
             self.assertEqual(len(series_list), len(mock_data_series))
             for series in series_list:
-                self.assertTrue('metric_id' in series)
-                self.assertTrue('source_id' in series)
+                self.assertTrue("metric_id" in series)
+                self.assertTrue("source_id" in series)

--- a/api/client/batch_client_test.py
+++ b/api/client/batch_client_test.py
@@ -123,7 +123,7 @@ class GroClientTests(TestCase):
         self.assertEqual(data_points[0][1]['start_date'], '2018-01-01T00:00:00.000Z')
         self.assertEqual(data_points[0][1]['end_date'], '2018-12-31T00:00:00.000Z')
         self.assertEqual(data_points[0][1]['value'], 56789)
-        self.assertEqual(data_points[0][1]['unit_id'], 14)
+        self.assertEqual(data_points[0][1]['unit_id'], 10)
         self.assertEqual(data_points[0][1]['reporting_date'], '2019-03-14T00:00:00.000Z')
 
     def test_batch_async_get_data_points_map_function(self):

--- a/api/client/batch_client_test.py
+++ b/api/client/batch_client_test.py
@@ -58,7 +58,7 @@ def mock_tornado_fetch(request):
     "tornado.httpclient.AsyncHTTPClient.fetch",
     MagicMock(side_effect=mock_tornado_fetch),
 )
-class GroClientTests(TestCase):
+class BatchClientTests(TestCase):
     def setUp(self):
         self.client = BatchClient(MOCK_HOST, MOCK_TOKEN)
         self.assertTrue(isinstance(self.client, BatchClient))

--- a/api/client/mock_data.py
+++ b/api/client/mock_data.py
@@ -1,72 +1,174 @@
 # TODO: move mocks into conftest.py
 
 mock_entities = {
-    'metrics': {
-        860032: {'id': 860032, 'name': 'Production Quantity', 'contains': [], 'belongsTo': []}
+    "metrics": {
+        860032: {
+            "id": 860032,
+            "name": "Production Quantity",
+            "contains": [],
+            "belongsTo": [],
+        }
     },
-    'items': {},
-    'regions': {
-        0: {'id': 0, 'level': 1, 'name': 'World', 'contains': [1215], 'belongsTo': []},
-        1215: {'id': 1215, 'level': 3, 'name': 'United States', 'contains': [12345], 'belongsTo': [0]},
-        12345: {'id': 12345, 'level': 4,  'name': 'Minnesota', 'contains': [], 'belongsTo': [1215]}
+    "items": {},
+    "regions": {
+        0: {"id": 0, "level": 1, "name": "World", "contains": [1215], "belongsTo": []},
+        1215: {
+            "id": 1215,
+            "level": 3,
+            "name": "United States",
+            "contains": [12345],
+            "belongsTo": [0],
+        },
+        12345: {
+            "id": 12345,
+            "level": 4,
+            "name": "Minnesota",
+            "contains": [],
+            "belongsTo": [1215],
+        },
     },
-    'frequencies': {},
-    'sources': {},
-    'units': {
-        10: {'id': 10, 'abbreviation': 'kg', 'name': 'kilogram', 'baseConvFactor': {'factor': 1}, 'convType': 0},
-        14: {'id': 14, 'name': 'tonne', 'baseConvFactor': {'factor': 1000}, 'convType': 0},
-        36: {'id': 36, 'name': 'Celsius', 'baseConvFactor': {'factor': 1, 'offset': 273}, 'convType': 1},
-        37: {'id': 37, 'name': 'Fahrenheit', 'baseConvFactor': {'factor': 0.5, 'offset': 255}, 'convType': 1},
-        43: {'id': 43, 'name': 'US Dollar (constant 2010)', 'baseConvFactor': {'factor': None}, 'convType': 0}
-    }
+    "frequencies": {},
+    "sources": {},
+    "units": {
+        10: {
+            "id": 10,
+            "abbreviation": "kg",
+            "name": "kilogram",
+            "baseConvFactor": {"factor": 1},
+            "convType": 0,
+        },
+        14: {
+            "id": 14,
+            "name": "tonne",
+            "baseConvFactor": {"factor": 1000},
+            "convType": 0,
+        },
+        36: {
+            "id": 36,
+            "name": "Celsius",
+            "baseConvFactor": {"factor": 1, "offset": 273},
+            "convType": 1,
+        },
+        37: {
+            "id": 37,
+            "name": "Fahrenheit",
+            "baseConvFactor": {"factor": 0.5, "offset": 255},
+            "convType": 1,
+        },
+        43: {
+            "id": 43,
+            "name": "US Dollar (constant 2010)",
+            "baseConvFactor": {"factor": None},
+            "convType": 0,
+        },
+    },
 }
 
 mock_data_series = [
     {
-        'metric_id': 860032,  # TODO: add names
-        'item_id': 274,
-        'region_id': 1215,
-        'partner_region_id': 0,
-        'frequency_id': 9,
-        'source_id': 2
-    }, {
-        'metric_id': 860032,  # TODO: add names
-        'item_id': 274,
-        'region_id': 1216,
-        'partner_region_id': 0,
-        'frequency_id': 9,
-        'source_id': 2
+        "metric_id": 860032,  # TODO: add names
+        "item_id": 274,
+        "region_id": 1215,
+        "partner_region_id": 0,
+        "frequency_id": 9,
+        "source_id": 2,
+    },
+    {
+        "metric_id": 860032,  # TODO: add names
+        "item_id": 274,
+        "region_id": 1216,
+        "partner_region_id": 0,
+        "frequency_id": 9,
+        "source_id": 2,
+    },
+]
+
+mock_list_of_series_points = [
+    {
+        "series": {
+            "metricId": 860032,
+            "itemId": 274,
+            "regionId": 1215,
+            "partnerRegionId": 0,
+            "frequencyId": 9,
+            "sourceId": 2,
+            "unitId": 14,
+            "belongsTo": {
+                "metricId": 860032,
+                "itemId": 274,
+                "regionId": 1215,
+                "frequencyId": 9,
+                "sourceId": 2,
+            },
+        },
+        "data": [
+            [
+                "2017-01-01T00:00:00.000Z",
+                "2017-12-31T00:00:00.000Z",
+                40891,
+                None,
+                14,
+                {},
+            ],
+            [
+                "2018-01-01T00:00:00.000Z",
+                "2018-12-31T00:00:00.000Z",
+                56789,
+                "2019-03-14T00:00:00.000Z",
+                10,
+                {},
+            ],
+        ],
     }
 ]
 
 mock_data_points = [
     {
-        'start_date': '2017-01-01T00:00:00.000Z',
-        'end_date': '2017-12-31T00:00:00.000Z',
-        'value': 40891, 'unit_id': 14,
-        'reporting_date': None,
-        'metric_id': 860032, 'item_id': 274, 'region_id': 1215,
-        'partner_region_id': 0, 'frequency_id': 9, 'source_id': 2,
-        'belongs_to': {
-            'metric_id': 860032,
-            'item_id': 274,
-            'region_id': 1215,
-            'frequency_id': 9,
-            'source_id': 2
-        }
-    }, {
-        'start_date': '2017-01-01T00:00:00.000Z',
-        'end_date': '2017-12-31T00:00:00.000Z',
-        'value': 56789, 'unit_id': 10,
-        'reporting_date': None,
-        'metric_id': 860032, 'item_id': 274, 'region_id': 1216,
-        'partner_region_id': 0, 'frequency_id': 9, 'source_id': 2,
-        'belongs_to': {
-            'metric_id': 860032,
-            'item_id': 274,
-            'region_id': 1216,
-            'frequency_id': 9,
-            'source_id': 2
-        }
-    }
+        "start_date": "2017-01-01T00:00:00.000Z",
+        "end_date": "2017-12-31T00:00:00.000Z",
+        "value": 40891,
+        "unit_id": 14,
+        "reporting_date": None,
+        "metric_id": 860032,
+        "item_id": 274,
+        "region_id": 1215,
+        "partner_region_id": 0,
+        "frequency_id": 9,
+        "source_id": 2,
+        "belongs_to": {
+            "metric_id": 860032,
+            "item_id": 274,
+            "region_id": 1215,
+            "frequency_id": 9,
+            "source_id": 2,
+        },
+    },
+    {
+        "start_date": "2017-01-01T00:00:00.000Z",
+        "end_date": "2017-12-31T00:00:00.000Z",
+        "value": 56789,
+        "unit_id": 10,
+        "reporting_date": None,
+        "metric_id": 860032,
+        "item_id": 274,
+        "region_id": 1216,
+        "partner_region_id": 0,
+        "frequency_id": 9,
+        "source_id": 2,
+        "belongs_to": {
+            "metric_id": 860032,
+            "item_id": 274,
+            "region_id": 1216,
+            "frequency_id": 9,
+            "source_id": 2,
+        },
+    },
 ]
+
+mock_error_selection = {
+    "metric_id": 1,
+    "item_id": -15,
+    "region_id": 3,
+    "frequency_id": 4,
+    "source_id": 5,
+}


### PR DESCRIPTION
https://github.com/gro-intelligence/api-client/pull/223 was merged but never pulled into https://github.com/gro-intelligence/api-client/pull/224 so when the latter was merged to dev, this test failed: https://app.shippable.com/github/gro-intelligence/api-client/runs/3223/1/console

Now because of https://github.com/gro-intelligence/api-client/pull/223, the unit id is being read from the point instead of from the series, by default. So in our `mock_list_of_series_points` variable we have two different ones:

```py
['2017-01-01T00:00:00.000Z', '2017-12-31T00:00:00.000Z', 40891, None, 14, {}],
['2018-01-01T00:00:00.000Z', '2018-12-31T00:00:00.000Z', 56789, '2019-03-14T00:00:00.000Z', 10, {}],
```

14 and 10. Old way was it was reading the 14 from

```py
'series': {
  'unitId': 14,
  ...
}
```

and ignoring the 10 on the point.