### PR TITLE
Copy selections passed to add_single_data_series

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -7,6 +7,7 @@ import getpass
 import itertools
 import os
 import sys
+import json
 
 from api.client import cfg, lib
 from api.client.constants import DATA_SERIES_UNIQUE_TYPES_ID, ENTITY_KEY_TO_TYPE
@@ -535,6 +536,12 @@ class GroClient(object):
         data_points : list of dicts
 
         """
+
+        for point in data_points:
+            for key, value in point.items():
+                if isinstance(value, dict):
+                    point[key] = json.dumps(value)
+
         tmp = pandas.DataFrame(data=data_points)
         if tmp.empty:
             return

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -7,7 +7,6 @@ import getpass
 import itertools
 import os
 import sys
-import json
 
 from api.client import cfg, lib
 from api.client.constants import DATA_SERIES_UNIQUE_TYPES_ID, ENTITY_KEY_TO_TYPE

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -766,7 +766,8 @@ class GroClient(object):
         series_hash = frozenset(data_series.items())
         if series_hash not in self._data_series_list:
             self._data_series_list.add(series_hash)
-            self._data_series_queue.append(data_series)
+            # Add a copy of the data series, in case the original is modified
+            self._data_series_queue.append(dict(data_series))
             self._logger.info("Added {}".format(data_series))
         else:
             self._logger.debug("Already added: {}".format(data_series))

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -11,7 +11,7 @@ import json
 
 from api.client import cfg, lib
 from api.client.constants import DATA_SERIES_UNIQUE_TYPES_ID, ENTITY_KEY_TO_TYPE
-from api.client.utils import intersect, zip_selections
+from api.client.utils import intersect, zip_selections, dict_unnest
 
 import pandas
 import unicodecsv
@@ -537,12 +537,7 @@ class GroClient(object):
 
         """
 
-        for point in data_points:
-            for key, value in point.items():
-                if isinstance(value, dict):
-                    point[key] = json.dumps(value)
-
-        tmp = pandas.DataFrame(data=data_points)
+        tmp = pandas.DataFrame(data=[dict_unnest(point) for point in data_points])
         if tmp.empty:
             return
         # get_data_points response doesn't include the

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -144,10 +144,16 @@ def mock_get_top(access_token, api_host, entity_type, num_results, **selection):
 
 def mock_get_data_points(access_token, api_host, **selections):
     if isinstance(selections["region_id"], int):
-        print("mock_data_points[0]", mock_data_points[0])
-        return [dict(mock_data_points[0])]
+        data_point = dict(mock_data_points[0])
+        data_point["region_id"] = selections["region_id"]
+        return [data_point]
     elif isinstance(selections["region_id"], list):
-        return [dict(mock_data_points[0]), dict(mock_data_points[1])]
+        data_points = []
+        for idx, region_id in enumerate(selections["region_id"]):
+            data_point = dict(mock_data_points[idx % 2])
+            data_point["region_id"] = region_id
+            data_points.append(data_point)
+        return data_points
 
 
 @patch("api.client.lib.get_available", MagicMock(side_effect=mock_get_available))
@@ -303,6 +309,20 @@ class GroClientTests(TestCase):
         # should be ignored.
         df = self.client.GDH("860032-274-1215-0-2-9", insert_nulls=True, metric_id=1)
         self.assertEqual(len(df), 0)
+
+    def test_add_single_data_series(self):
+        selections = dict(mock_data_series[0])
+        for region_id in [
+            mock_data_series[0]["region_id"],
+            mock_data_series[1]["region_id"],
+        ]:
+            selections["region_id"] = region_id
+            self.client.add_single_data_series(selections)
+        print(self.client.get_data_series_list())
+        print("QUEUE", self.client._data_series_queue)
+        self.assertEqual(
+            len(self.client.get_df().drop_duplicates().region_id.unique()), 2
+        )
 
     def test_get_data_series_list(self):
         self.client.add_single_data_series(mock_data_series[0])

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -145,11 +145,15 @@ def mock_get_top(access_token, api_host, entity_type, num_results, **selection):
 def mock_get_data_points(access_token, api_host, **selections):
     if isinstance(selections["region_id"], int):
         data_point = dict(mock_data_points[0])
+        # set the data_point to use the selected region
+        # other ids in mocked data points may not line up with selected ids
         data_point["region_id"] = selections["region_id"]
         return [data_point]
     elif isinstance(selections["region_id"], list):
         data_points = []
         for idx, region_id in enumerate(selections["region_id"]):
+            # use mock_data_points[0] or mock_data_points[1] as a base depending if
+            # index is even or odd
             data_point = dict(mock_data_points[idx % 2])
             data_point["region_id"] = region_id
             data_points.append(data_point)
@@ -311,15 +315,16 @@ class GroClientTests(TestCase):
         self.assertEqual(len(df), 0)
 
     def test_add_single_data_series(self):
-        selections = dict(mock_data_series[0])
+        selections = dict(mock_data_series[0])  # don't modify test data. Make a copy
         for region_id in [
             mock_data_series[0]["region_id"],
             mock_data_series[1]["region_id"],
         ]:
+            # modify the original selections object
             selections["region_id"] = region_id
+            # if add_single_data_series isn't making a copy of the selections passed in,
+            # then this test should fail since the original reference has been modified.
             self.client.add_single_data_series(selections)
-        print(self.client.get_data_series_list())
-        print("QUEUE", self.client._data_series_queue)
         self.assertEqual(
             len(self.client.get_df().drop_duplicates().region_id.unique()), 2
         )

--- a/api/client/utils.py
+++ b/api/client/utils.py
@@ -66,6 +66,33 @@ def dict_reformat_keys(obj, format_func):
     return {format_func(key): value for key, value in obj.items()}
 
 
+def dict_unnest(obj):
+    """Flatten a dictionary containing other dictionaries by concatenating their keys.
+
+    Parameters
+    ----------
+    obj : dict
+        A dictionary, which may or may not contain other dictionaries
+
+    Returns
+    -------
+    dict
+        A new dictionary, which has been reformatted
+
+    """
+    flat_obj = {}
+    for key, value in obj.items():
+        if isinstance(value, dict):
+            for sub_key, sub_value in dict_unnest(value).items():
+                flat_obj["{}_{}".format(key, sub_key)] = sub_value
+        elif isinstance(value, list):
+            for idx, sub_value in enumerate(value):
+                flat_obj["{}_{}".format(key, idx)] = sub_value
+        else:
+            flat_obj[key] = value
+    return flat_obj
+
+
 def list_chunk(arr, chunk_size=50):
     """Chunk an array into chunks of a given max length.
 

--- a/api/client/utils_test.py
+++ b/api/client/utils_test.py
@@ -4,6 +4,7 @@ from api.client.utils import (
     str_camel_to_snake,
     str_snake_to_camel,
     dict_reformat_keys,
+    dict_unnest,
     list_chunk,
     intersect,
     zip_selections,
@@ -28,6 +29,29 @@ class UtilsTests(TestCase):
         self.assertEqual(
             dict_reformat_keys({"belongs_to": {"metric_id": 4}}, str_snake_to_camel),
             {"belongsTo": {"metric_id": 4}},
+        )
+
+    def test_dict_unnest(self):
+        self.assertEqual(
+            dict_unnest({"metric_id": 14, "belongs_to": {"metric_id": 14}}),
+            {"metric_id": 14, "belongs_to_metric_id": 14},
+        )
+
+        self.assertEqual(
+            dict_unnest(
+                {
+                    "metric_id": 14,
+                    "belongs_to": {
+                        "metric_id": 14,
+                        "metadata": {"includes_historical": True},
+                    },
+                }
+            ),
+            {
+                "metric_id": 14,
+                "belongs_to_metric_id": 14,
+                "belongs_to_metadata_includes_historical": True,
+            },
         )
 
     def test_list_chunk(self):


### PR DESCRIPTION
See the added test:

```py
        for region_id in [
            mock_data_series[0]["region_id"],
            mock_data_series[1]["region_id"],
        ]:
            selections["region_id"] = region_id
            self.client.add_single_data_series(selections)
        self.assertEqual(
            len(self.client.get_df().drop_duplicates().region_id.unique()), 2
        )
```

This would fail before because a reference to the original `selections` dictionary would be added to `client._data_series_queue`, and then when the for loop iterates, it modifies that original. So, `client._data_series_queue` would end up with two references to the same object, both of which would have the same region id (`mock_data_series[1]["region_id"]`).

This is incongruous with `client._data_series_list` which has a frozenset copy made before being added to the list. So `_data_series_list` would end up with two different series, while queue only has two references to 1 series.

Now, we make copies of the passed-in data series, so there can no longer be that inconsistency.