### PR TITLE
Increase find_data_series test coverage and fix start_date/end_date bug

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -542,13 +542,11 @@ class GroClient(object):
         # get_data_points response doesn't include the
         # source_id. We add it as a column, in case we have
         # several selections series which differ only by source id.
-        tmp["source_id"] = data_series["source_id"]
-        if "end_date" in tmp.columns:
-            tmp.end_date = pandas.to_datetime(tmp.end_date)
-        if "start_date" in tmp.columns:
-            tmp.start_date = pandas.to_datetime(tmp.start_date)
-        if "reporting_date" in tmp.columns:
-            tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
+        tmp.source_id = data_series["source_id"]
+        # tmp should always have end_date/start_date/reporting_date as columns if not empty
+        tmp.end_date = pandas.to_datetime(tmp.end_date)
+        tmp.start_date = pandas.to_datetime(tmp.start_date)
+        tmp.reporting_date = pandas.to_datetime(tmp.reporting_date)
 
         if self._data_frame.empty:
             self._data_frame = tmp

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -765,7 +765,7 @@ class GroClient(object):
             self._logger.debug("Already added: {}".format(data_series))
         return
 
-    def find_data_series(self, **kwargs):
+    def find_data_series(self, result_filter=None, **kwargs):
         """Find data series matching a combination of entities specified by
         name and yield them ranked by coverage.
 
@@ -850,6 +850,7 @@ class GroClient(object):
                 data_series.pop("start_date", None)
                 data_series.pop("end_date", None)
                 data_series.pop("frequency_id", None)
+                data_series.pop("frequency_name", None)
                 # remove source to rank them
                 data_series.pop("source_id", None)
                 data_series.pop("source_name", None)

--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -825,19 +825,19 @@ class GroClient(object):
         :meth:`~.get_data_series`
 
         """
-        result_filter = kwargs.pop("result_filter", lambda x: True)
         results = []  # [[('item_id',1),('item_id',2),...],[('metric_id" 1),...],...]
         for kw in kwargs:
             id_key = "{}_id".format(kw)
-            results.append(
-                [
-                    (id_key, result["id"])
-                    for result in filter(
-                        lambda entity: result_filter({id_key: entity["id"]}),
-                        self.search(ENTITY_KEY_TO_TYPE[id_key], kwargs[kw]),
-                    )
-                ][: cfg.MAX_RESULT_COMBINATION_DEPTH]
-            )
+            if id_key in ENTITY_KEY_TO_TYPE:
+                type_results = []  # [('item_id',1),('item_id',2),...]
+                for search_result in self.search(
+                    ENTITY_KEY_TO_TYPE[id_key], kwargs[kw]
+                )[: cfg.MAX_RESULT_COMBINATION_DEPTH]:
+                    if result_filter is None or result_filter(
+                        {id_key: search_result["id"]}
+                    ):
+                        type_results.append((id_key, search_result["id"]))
+                results.append(type_results)
         # Rank by frequency and source, while preserving search ranking in
         # permutations of search results.
         ranking_groups = set()

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -339,7 +339,29 @@ class GroClientTests(TestCase):
         # TODO: when duplicates are removed, this should equal 2:
         self.assertEqual(
             len(
-                list(self.client.find_data_series(metric="Production", region="United"))
+                list(
+                    self.client.find_data_series(
+                        metric="Production",
+                        region="United",
+                        start_date="2000-01-01",
+                        end_date="2005-12-31",
+                    )
+                )
+            ),
+            8,
+        )
+
+        # TODO: when duplicates are removed, this should equal 2:
+        def only_accept_production_quantity(search_result):
+            return "metric_id" not in search_result or search_result["metric_id"] == 860032
+        self.assertEqual(
+            len(
+                list(
+                    self.client.find_data_series(
+                        metric="Production",
+                        result_filter=only_accept_production_quantity
+                    )
+                )
             ),
             8,
         )

--- a/api/client/mock_data.py
+++ b/api/client/mock_data.py
@@ -6,7 +6,13 @@ mock_entities = {
             "id": 860032,
             "name": "Production Quantity",
             "contains": [],
-            "belongsTo": [],
+            "belongsTo": [119],
+        },
+        860033: {
+            "id": 3341078,
+            "name": "Production Value",
+            "contains": [],
+            "belongsTo": [119],
         }
     },
     "items": {},


### PR DESCRIPTION
Refactoring:

1. I don't know of any instance in which `if "end_date" in tmp.columns:` etc. would not be true, unless the dataframe was empty, which is already handled above. Removed them because it seems like an unnecessary conditional.
2. Giving `result_filter` a default value of `None` eliminates a little bit of complexity, not having to pop off of `kwargs`

Bug fixes:

1. `source_id` and `source_name` were being popped off of selections before going into ranking, but only `frequency_id` was. So `frequency_name` could still get out of sync. Removed `frequency_name` as well. Related: https://github.com/gro-intelligence/api-client/pull/185#discussion_r396763536
2. `start_date` and `end_date` inputs to `find_data_series` were broken because it attempts to get the entity type of the key `start_date_id`/`end_date_id` [here](https://github.com/gro-intelligence/api-client/pull/231/files#diff-603e79178b8e522d0e366a9fca477b24R834) to pass into search. That results in a `KeyError`