### PR TITLE
CLEWS-28861: lock pytest-cov version at 2.9.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,7 @@ mock
 numpy<=v1.16.6  # last version to support python 2
 pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 pytest
-pytest-cov
+pytest-cov==2.9.0
 scikit-learn<0.21.0  # last version to support Python 2
 scipy<v1.3.0  # 1.2.* is the Python 2 LTS release
 seaborn


### PR DESCRIPTION
pytest-cov 2.10.0 increased the minimum pytest version from 3.6 to 4.6: https://github.com/pytest-dev/pytest-cov/compare/v2.9.0...v2.10.0#diff-2eeaed663bd0d25b7e608891384b7298R125

We're currently resolving to 4.2.1, so we no longer meet the minimum version requirement. Rolling back to 2.9.0 as a quick fix to see if that allows tests to go through. Follow-up should be to figure out what's causing us to stop at pytest 4.2.1.

Pytest 5.0.0 removes Python 2 support, but based on python_requires we should still be able to go up to pytest 4.6.11.