### PR TITLE
CLEWS-29515: convert data series hashes to dicts

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -1101,7 +1101,7 @@ class GroClient(object):
             A list of data_series objects, as returned by :meth:`~.get_data_series`.
 
         """
-        return list(self._data_series_list)
+        return [dict(data_series_hash) for data_series_hash in self._data_series_list]
 
     def add_single_data_series(self, data_series):
         """Save a data series object to the GroClient's data_series_list.

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -369,8 +369,7 @@ class GroClientTests(TestCase):
 
     def test_get_data_series_list(self):
         self.client.add_single_data_series(mock_data_series[0])
-        for idx, elem in enumerate(self.client.get_data_series_list()[0]):
-            key, value = elem
+        for key, value in self.client.get_data_series_list()[0].items():
             self.assertEqual(value, mock_data_series[0][key])
 
     def test_find_data_series(self):
@@ -408,8 +407,7 @@ class GroClientTests(TestCase):
         # TODO: when duplicates are removed, this should equal 2:
         data_series = self.client.add_data_series(metric="Production", region="United")
         self.assertEqual(data_series, mock_data_series[0])
-        for idx, elem in enumerate(self.client.get_data_series_list()[0]):
-            key, value = elem
+        for key, value in self.client.get_data_series_list()[0].items():
             self.assertEqual(value, mock_data_series[0][key])
 
     def test_search_for_entity(self):


### PR DESCRIPTION
As a result of https://github.com/gro-intelligence/api-client/pull/195 `get_data_series_list()` was returning a list of frozensets instead of a list of dicts, inconsistent with the docstring. This was resulting in a `crop_models/sugar.py` failure:

https://github.com/gro-intelligence/api-client/blob/06fd547d36db8c1a89f5bd505b7fe73221d9127d/api/client/samples/crop_models/sugar.py#L57

It's not able to access elements of a frozenset by key. This PR converts the output from frozenset back to dict, and now sugar.py runs.