### PR TITLE
CLEWS-29523: pandas dot notation does not add a column

### DIFF
--- a/api/client/gro_client.py
+++ b/api/client/gro_client.py
@@ -907,7 +907,7 @@ class GroClient(object):
         # get_data_points response doesn't include the
         # source_id. We add it as a column, in case we have
         # several selections series which differ only by source id.
-        tmp.source_id = data_series["source_id"]
+        tmp["source_id"] = data_series["source_id"]
         # tmp should always have end_date/start_date/reporting_date as columns if not empty
         tmp.end_date = pandas.to_datetime(tmp.end_date)
         tmp.start_date = pandas.to_datetime(tmp.start_date)

--- a/api/client/gro_client_test.py
+++ b/api/client/gro_client_test.py
@@ -327,6 +327,9 @@ class GroClientTests(TestCase):
         self.assertEqual(
             self.client.get_df().iloc[0]["start_date"].date(), date(2017, 1, 1)
         )
+        self.assertEqual(
+            self.client.get_df().iloc[0]["source_id"], 2
+        )
 
     def test_get_data_points(self):
         # Gives the point's default unit if unit's not specified:

--- a/api/client/mock_data.py
+++ b/api/client/mock_data.py
@@ -97,7 +97,7 @@ mock_list_of_series_points = [
             "regionId": 1215,
             "partnerRegionId": 0,
             "frequencyId": 9,
-            "sourceId": 2,
+            # "sourceId": 2,
             "unitId": 14,
             "belongsTo": {
                 "metricId": 860032,
@@ -140,7 +140,7 @@ mock_data_points = [
         "region_id": 1215,
         "partner_region_id": 0,
         "frequency_id": 9,
-        "source_id": 2,
+        # "source_id": 2,
         "belongs_to": {
             "metric_id": 860032,
             "item_id": 274,
@@ -160,7 +160,7 @@ mock_data_points = [
         "region_id": 1216,
         "partner_region_id": 0,
         "frequency_id": 9,
-        "source_id": 2,
+        # "source_id": 2,
         "belongs_to": {
             "metric_id": 860032,
             "item_id": 274,


### PR DESCRIPTION
Was changed from bracket notation to dot notation in https://github.com/gro-intelligence/api-client/commit/5b0171d836874a5ecf33c5f3b4c9d4fdc7370a04 to be consistent with the date columns' syntax, but pandas does not allow that syntax for adding columns. See https://pandas.pydata.org/docs/user_guide/indexing.html?highlight=attribute%20access#attribute-access

Tested by running brazil_soybeans.ipynb

The existing unit tests for `index_by_series=True` would have also caught this, except that the mock for `mock_data_points` included `source_id` whereas the real `get_data_points()` endpoint does not output source_id. Adjusted the mock so it is more representative of the current output.