### PR TITLE
Fall back to None status code if APIError response is not an HTTP response

### DIFF
--- a/api/client/lib.py
+++ b/api/client/lib.py
@@ -29,7 +29,7 @@ class APIError(Exception):
         self.retry_count = retry_count
         self.url = url
         self.params = params
-        self.status_code = self.response.status_code
+        self.status_code = response.status_code if hasattr(response, 'status_code') else None
         try:
             json_content = self.response.json()
             # 'error' should be something like 'Not Found' or 'Bad Request'


### PR DESCRIPTION
To avoid the error

```py
AttributeError: 'ConnectionError' object has no attribute 'status_code'
```

Now, when a ConnectionError is raised, APIError parses it correctly:

```py
APIError: (ConnectionError(), 5, 'https://api.gro-intelligence.com/v2/regions', {'ids': [1215]})
```