### PR TITLE
CLEWS-25132 find_packages

### DIFF
--- a/api/client/__init__.py
+++ b/api/client/__init__.py
@@ -1,2 +1,2 @@
 from groclient import GroClient as Client
-from groclient import lib, cfg
+from groclient import lib, cfg, utils

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/gro-intelligence/api-client",
-    packages=['groclient'],
+    packages=setuptools.find_packages(),
     python_requires=">=2.7.12, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     install_requires=requirements,
     extras_require={


### PR DESCRIPTION
Tested in fresh virtual environments:

Before:

```
$ pipenv install git+https://github.com/gro-intelligence/api-client.git#egg=groclient ipython
$ ipython
In [1]: from api.client.gro_client import GroClient
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-8aa8732af4ee> in <module>
----> 1 from api.client.gro_client import GroClient

ModuleNotFoundError: No module named 'api'
```

After:

```
$ pipenv install git+https://github.com/gro-intelligence/api-client.git@CLEWS-25132-find-packages#egg=groclient ipython
$ ipython
In [1]: from api.client.gro_client import GroClient

In [2]: from api.client import utils

In [3]:
```

Two things hid this while testing https://github.com/gro-intelligence/api-client/pull/234:

1. When installing in editable mode `-e` it still gets the `api/` folder
2. When upgrading an existing installation, the old package is not removed

Need to install both api and groclient packages for the aliases to work when installing from scratch.

Also, `api.client.utils` did not have an alias. Added that.