### PR TITLE
CLEWS-25132: hoist CropModel

### DIFF
--- a/groclient/__init__.py
+++ b/groclient/__init__.py
@@ -1,2 +1,2 @@
 from groclient.client import GroClient
-from groclient import lib
+from groclient.crop_model import CropModel


### PR DESCRIPTION
So now you can do `from groclient import CropModel` instead of `from groclient.crop_model import CropModel`

The `from groclient import lib` line was also removed since it wasn't doing anything. You can still `from groclient import lib` or `import groclient.lib` without it in the `__init__.py`