### PR TITLE
CLEWS-29688 | CLEWS-23863: random data series picking in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ python crop_models/soybeans.py
 gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --user_email="email@example.com"
 ```
 
-The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called `gro_client_output.csv`. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.
+The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked and the data points to the console. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.
 
 Further documentation can be found in the [api/client/](api/client) directory and on our [wiki](https://github.com/gro-intelligence/api-client/wiki).

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -1,13 +1,53 @@
+from random import random
 import argparse
 import getpass
 import os
 import sys
+import unicodecsv
 
 import groclient.lib
 import groclient.cfg
 from groclient import GroClient
 
 OUTPUT_FILENAME = "gro_client_output.csv"
+
+
+def pick_random_data_series(client):  # pragma: no cover
+    """Given a selection of entities, pick a random available data series the given selection
+    of entities.
+    """
+    data_series_list = client.get_data_series()
+    random_data_series = data_series_list[int(len(data_series_list) * random())]
+    return random_data_series
+
+
+def print_one_data_series(client, data_series):  # pragma: no cover
+    """Output a data series to stdout."""
+    print('{} {} of {} in {}:'.format(data_series['frequency_name'],
+                                      data_series['metric_name'],
+                                      data_series['item_name'],
+                                      data_series['region_name']))
+    for point in client.get_data_points(**data_series):
+        print('{}-{}: {} {}'.format(point["start_date"],
+                                    point["end_date"],
+                                    point["value"],
+                                    client.lookup_unit_abbreviation(point["unit_id"])))
+
+
+def write_one_data_series(client, data_series, filename):  # pragma: no cover
+    """Output a data series to a CSV file."""
+    client.get_logger().warning("Using data series: {}".format(str(data_series)))
+    client.get_logger().warning("Outputing to file: {}".format(filename))
+    writer = unicodecsv.writer(open(filename, "wb"))
+    for point in client.get_data_points(**data_series):
+        writer.writerow(
+            [
+                point["start_date"],
+                point["end_date"],
+                point["value"],
+                client.lookup_unit_abbreviation(point["unit_id"]),
+            ]
+        )
 
 
 def main():  # pragma: no cover
@@ -30,6 +70,7 @@ def main():  # pragma: no cover
     parser.add_argument("--metric")
     parser.add_argument("--region")
     parser.add_argument("--partner_region")
+    parser.add_argument("--file")
     parser.add_argument(
         "--print_token",
         action="store_true",
@@ -67,9 +108,9 @@ def main():  # pragma: no cover
         and not args.region
         and not args.partner_region
     ):
-        ds = client.pick_random_data_series(client.pick_random_entities())
+        data_series = pick_random_data_series(client)
     else:
-        ds = next(
+        data_series = next(
             client.find_data_series(
                 item=args.item,
                 metric=args.metric,
@@ -77,4 +118,8 @@ def main():  # pragma: no cover
                 partner_region=args.partner_region,
             )
         )
-    client.print_one_data_series(ds, OUTPUT_FILENAME)
+
+    if args.file is not None:
+        write_one_data_series(client, data_series, args.file)
+    else:
+        print_one_data_series(client, data_series)

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -9,8 +9,6 @@ import groclient.lib
 import groclient.cfg
 from groclient import GroClient
 
-OUTPUT_FILENAME = "gro_client_output.csv"
-
 
 def pick_random_data_series(client):  # pragma: no cover
     """Given a selection of entities, pick a random available data series the given selection

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -11,20 +11,20 @@ from groclient import GroClient
 
 
 def pick_random_data_series(client):  # pragma: no cover
-    """Given a selection of entities, pick a random available data series the given selection
-    of entities.
-    """
+    """Pick a random available data series."""
     data_series_list = client.get_data_series()
     random_data_series = data_series_list[int(len(data_series_list) * random())]
     return random_data_series
 
 
 def print_one_data_series(client, data_series):  # pragma: no cover
-    """Output a data series to stdout."""
+    """Output the data points of a data series to stdout."""
+    # Print the "name" of the series:
     print('{} {} of {} in {}:'.format(data_series['frequency_name'],
                                       data_series['metric_name'],
                                       data_series['item_name'],
                                       data_series['region_name']))
+    # Print the data points:
     for point in client.get_data_points(**data_series):
         print('{}-{}: {} {}'.format(point["start_date"],
                                     point["end_date"],
@@ -33,7 +33,7 @@ def print_one_data_series(client, data_series):  # pragma: no cover
 
 
 def write_one_data_series(client, data_series, filename):  # pragma: no cover
-    """Output a data series to a CSV file."""
+    """Output the data points of a data series to a CSV file."""
     client.get_logger().warning("Using data series: {}".format(str(data_series)))
     client.get_logger().warning("Outputing to file: {}".format(filename))
     writer = unicodecsv.writer(open(filename, "wb"))

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -121,8 +121,13 @@ def main():  # pragma: no cover
                 metric=args.metric,
                 region=args.region,
                 partner_region=args.partner_region,
-            )
+            ),
+            None
         )
+
+    if data_series is None:
+        print("No data series found.")
+        return
 
     if args.file is not None:
         write_one_data_series(client, data_series, args.file)


### PR DESCRIPTION
Built on top of refactoring done in https://github.com/gro-intelligence/api-client/pull/249

* Move randomize code out of GroClient class and into cli.py
* Simplify `pick_random_data_series()` and deprecate `pick_random_entities()`

The way it was before, `pick_random_entities()` was returning start/end date which `pick_random_data_series()` was not expecting. That was one bug.

But also, in the `while not num:` loop it was calling `list_available()` (deprecated in favor of `get_data_series()` anyway) repeatedly without a guarantee of hitting a data series that actually exists. Instead, call `get_data_series()` once and pick a random result.

* Print results to console by default, instead of writing to a file.

This is more standard for a command line interface in my opinion, but there's also the option to save to a file if a filename is provided.

* skip arguments that are not provided

```py
if kwargs.get(kw) is None:
    continue
```

If you call `gro_client --metric production`, then `item=None`, `region=None`, and `partner_region=None`. Without this block to `continue`, you *have* to specify all 4.

* `yield self.get_data_series(**data_series)[0]`

This fixes the CLEWS-23863 issue where find_data_series output is different from get_data_series. All of the following issues are resolved by calling `get_data_series`:

1. missing start date and end date
2. missing frequency name and source name
3. missing metadata
4. data_count_estimate is incorrect