### PR TITLE
CLEWS-23890: Add version flag to gro_client cli

### DIFF
--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -41,7 +41,12 @@ def main():  # pragma: no cover
         default=os.environ.get("GROAPI_TOKEN"),
         help="Defaults to GROAPI_TOKEN environment variable.",
     )
+    parser.add_argument("--version", action="store_true")
     args = parser.parse_args()
+
+    if args.version:
+        print(groclient.lib.get_version_info().get('api-client-version'))
+        return
 
     assert (
         args.user_email or args.token
@@ -56,9 +61,11 @@ def main():  # pragma: no cover
         access_token = groclient.lib.get_access_token(
             groclient.cfg.API_HOST, args.user_email, args.user_password
         )
+
     if args.print_token:
         print(access_token)
-        sys.exit(0)
+        return
+
     client = GroClient(groclient.cfg.API_HOST, access_token)
 
     if (


### PR DESCRIPTION
This is a very minor quality of life feature to output the current client version to stdout. This is useful if doing bash scripting or if your client is installed in editable mode and pip doesn't update the meta info when pulling from development.

Now you can do:

```py
$ gro_client --version
1.82.1.dev93+gf1f1255bdc.d20200818
```