### PR TITLE
CLEWS-31143 Avoid unhashable dicts when adding data series

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-from builtins import str
-from random import random
 import functools
 import itertools
 import time
@@ -20,7 +18,6 @@ from groclient.utils import intersect, zip_selections, dict_unnest
 from groclient.lib import APIError
 
 import pandas
-import unicodecsv
 from tornado import gen
 from tornado.escape import json_decode
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
@@ -1112,7 +1109,8 @@ class GroClient(object):
         None
 
         """
-        series_hash = frozenset(data_series.items())
+        series_hash = frozenset([pair for pair in data_series.items()
+                                 if pair[0] in DATA_SERIES_UNIQUE_TYPES_ID])
         if series_hash not in self._data_series_list:
             self._data_series_list.add(series_hash)
             # Add a copy of the data series, in case the original is modified

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1109,8 +1109,7 @@ class GroClient(object):
         None
 
         """
-        series_hash = frozenset([pair for pair in data_series.items()
-                                 if pair[0] in DATA_SERIES_UNIQUE_TYPES_ID])
+        series_hash = frozenset(dict_unnest(data_series).items())
         if series_hash not in self._data_series_list:
             self._data_series_list.add(series_hash)
             # Add a copy of the data series, in case the original is modified

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -374,6 +374,7 @@ class GroClientTests(TestCase):
         selections = dict(mock_data_series[0])
         selections['metadata'] = {'includes_historical_region': True}
         self.client.add_single_data_series(selections)
+        self.assertEqual(len(self.client.get_df().item_id), 1)
 
     def test_get_data_series_list(self):
         self.client.add_single_data_series(mock_data_series[0])

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -355,7 +355,7 @@ class GroClientTests(TestCase):
         df = self.client.GDH("860032-274-1215-0-2-9", insert_nulls=True, metric_id=1)
         self.assertEqual(len(df), 0)
 
-    def test_add_single_data_series(self):
+    def test_add_single_data_series_adds_copy(self):
         selections = dict(mock_data_series[0])  # don't modify test data. Make a copy
         for region_id in [
             mock_data_series[0]["region_id"],
@@ -369,6 +369,11 @@ class GroClientTests(TestCase):
         self.assertEqual(
             len(self.client.get_df().drop_duplicates().region_id.unique()), 2
         )
+
+    def test_add_single_data_series_allows_metadata(self):
+        selections = dict(mock_data_series[0])
+        selections['metadata'] = {'includes_historical_region': True}
+        self.client.add_single_data_series(selections)
 
     def test_get_data_series_list(self):
         self.client.add_single_data_series(mock_data_series[0])


### PR DESCRIPTION
Related to https://github.com/gro-intelligence/api-client/pull/147 where metadata is unhashable.

So, if using `get_data_series()` and passing the result directly into `add_single_data_series()`, it would fail if the data series had any metadata. Instead, run the data series through `unnest_dict`, so if the input is:

```py
{
        "metric_id": 860032,  # TODO: add names
        "item_id": 274,
        "region_id": 1215,
        "partner_region_id": 0,
        "frequency_id": 9,
        "source_id": 2,
        "metadata": {"includes_historical_region": True}
}
```

it gets converted to

```py
{
        "metric_id": 860032,  # TODO: add names
        "item_id": 274,
        "region_id": 1215,
        "partner_region_id": 0,
        "frequency_id": 9,
        "source_id": 2,
        "metadata_includes_historical_region": True}
}
```

which then *is* hashable and generates a frozen set like:

```py
frozenset({('partner_region_id', 0), ('metric_id', 860032), ('source_id', 2), ('region_id', 1215), ('item_id', 274), ('metadata_includes_historical_region', True), ('frequency_id', 9)})
```

This is preferable over filtering out data series properties that don't appear in `DATA_SERIES_UNIQUE_TYPES_ID` because `add_single_data_series` should support extra options like `at_time` and `show_revisions`.