### PR TITLE
CLEWS-23863: remove duplicates from rank_series_by_source

### DIFF
--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -432,7 +432,9 @@ def rank_series_by_source(access_token, api_host, selections_list):
         except ValueError:
             continue  # empty response
         for source_id in source_ids:
-            if source_id in series_by_source_id or None in series_by_source_id:
+            if source_id in series_by_source_id:
+                yield series_by_source_id[source_id]
+            if None in series_by_source_id:
                 yield dict_assign(series_without_source, 'source_id', source_id)
 
 

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -325,7 +325,7 @@ def test_rank_series_by_source(mock_requests_get):
     }
 
     expected = [
-        {type_id: full_data_series[type_id] for type_id in DATA_SERIES_UNIQUE_TYPES_ID},
+        full_data_series,
         dict_assign(partial_selections, 'source_id', mock_return[0]),
         dict_assign(partial_selections, 'source_id', mock_return[1]),
         dict_assign(partial_selections, 'source_id', mock_return[2])

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -302,15 +302,18 @@ def test_rank_series_by_source(mock_requests_get):
     mock_requests_get.return_value.json.return_value = mock_return
     mock_requests_get.return_value.status_code = 200
 
-    a = {'region_id': 13474, 'abc': 123, 'def': 123, 'ghe': 123, 'fij': 123,
-         'item_id': 3457, 'metric_id': 2540047,
-         'source_id': 123, 'source_name': 'dontcare'}
-    a.pop('abc')
-    a.pop('def')
-    a.pop('ghe')
-    a.pop('fij')
+    a = {'metric_id': 2540047,
+         'item_id': 3457,
+         'region_id': 13474,
+         'partner_region_id': 56789,
+         'source_id': 123,
+         'source_name': 'dontcare',
+         'frequency_id': 9,
+         'metadata': {'historical': True}}
 
-    b = {'item_id': 1457, 'region_id': 13474, 'metric_id': 2540047}
+    b = {'metric_id': 2540047,
+         'item_id': 1457,
+         'region_id': 13474}
     c = list(lib.rank_series_by_source(MOCK_TOKEN, MOCK_HOST, [a, b]))
 
     assert(len(c) == 6)

--- a/groclient/utils.py
+++ b/groclient/utils.py
@@ -93,6 +93,29 @@ def dict_unnest(obj):
     return flat_obj
 
 
+def dict_assign(obj, key, value):
+    """Chainable dictionary assignment. Returns a copy.
+
+    Parameters
+    ----------
+    obj : dict
+        A dictionary
+    key : string
+        Which attribute to set. May be a new attribute, or overwriting an existing one
+    value
+        A value of any type
+
+    Returns
+    -------
+    dict
+        A new dictionary, with the given attribute set to the given value
+
+    """
+    new_dict = dict(obj)
+    new_dict[key] = value
+    return new_dict
+
+
 def list_chunk(arr, chunk_size=50):
     """Chunk an array into chunks of a given max length.
 


### PR DESCRIPTION
Follow-up to https://github.com/gro-intelligence/api-client/pull/250#issuecomment-677676097

Currently, if you pass `rank_series_by_source` a list of data series, as output from `get_data_series`, the output can be confusing since it's duplicating those input series and just changing source ids. So source names and start/end dates and estimated data counts can all be misrepresented. For example:

```py
data_series_list = client.get_data_series(metric_id=570001, item_id=95, region_id=1094, frequency_id=9)
for data_series in data_series_list:
    print(data_series['source_id'], data_series['start_date'], data_series['end_date'], data_series['data_count_estimate'])
```

this shows the available data series as:

```py
2 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
14 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
19 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
50 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
```

On the development branch, the output of

```py
for data_series in client.rank_series_by_source(data_series_list):
    print(data_series['source_id'], data_series['start_date'], data_series['end_date'], data_series['data_count_estimate'])
```

is

```py
50 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
14 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
2 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
19 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
50 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
14 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
2 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
19 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
50 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
14 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
2 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
19 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
50 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
14 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
2 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
19 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
```

Rather than re-arranging the inputs series, it's going through iteratively and swapping out just source ids, keeping the incorrect start/end dates and data counts.

With this PR, the same code now outputs

```py
50 1997-07-01T00:00:00.000Z 2018-06-30T00:00:00.000Z 22
14 1960-01-01T00:00:00.000Z 2021-03-31T00:00:00.000Z 62
2 1961-01-01T00:00:00.000Z 2018-12-31T00:00:00.000Z 59
19 1999-01-01T00:00:00.000Z 2016-12-31T00:00:00.000Z 19
```

which better meets expectations of how this function would work. Still works with partial selections, as well as full data series inputs.