### PR TITLE
feat: teardown tornado resources when groclient is deleted

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -73,6 +73,11 @@ class GroClient(object):
             )
             self._async_http_client = None
             self._ioloop = None
+        
+    def __del__(self):
+        self._async_http_client.close()
+        self._ioloop.stop()
+        self._ioloop.close()
 
     def get_logger(self):
         return self._logger


### PR DESCRIPTION
My test script:

```py
from groclient import GroClient
from tqdm import tqdm

import os

client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])
regions = {}

counter = 0
for region in tqdm(client.get_descendant_regions(0, include_details=False)):
    try:
        client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])
        regions[region['id']] = client.lookup('regions', region['id'])['name']
        counter += 1
    except Exception as e:
        print(counter, e)
        break
```

Before this change, after 80 GroClients get created, there's an error:

```py
HTTPSConnectionPool(host='api.gro-intelligence.com', port=443): Max retries exceeded with url: /v2/regions?ids=1073 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x11931c8d0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))` error
```

But, with this `__del__` method in place, I'm able to initialize more. Tested up to 350.

If I modify my test script to keep all the created clients in a list, then the limit of 80 *still exists*:

```py
from groclient import GroClient
from tqdm import tqdm

import os

client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])
clients = []
regions = {}

counter = 0
for region in tqdm(client.get_descendant_regions(0, include_details=False)):
    try:
        clients.append(GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN']))
        regions[region['id']] = clients[-1].lookup('regions', region['id'])['name']
        counter += 1
    except Exception as e:
        print(counter, e)
        break
```

But if the variable's being overwritten, or if `del` is explicitly called, then it's good.