### PR TITLE
CLEWS-15764 Build & Publish Package Using Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
-format-jinja = "{{ base }}{% if distance > 0 %}b{{ distance }}{% endif %}"
+format-jinja = "{% if distance > 0 %}{{ bump_version(base) }}b{{ distance }}{% else %}{{ base }}{% endif %}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
+format-jinja = "{{ base }}{% if distance > 0 %}b{{ distance }}{% endif %}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,15 @@ gro_client = 'groclient.__main__:main'
 
 [tool.poetry.dependencies]
 python = ">=3.6.1,<4.0"
-numpy = "^1.19.2"
-requests = "^2.24.0"
-pandas = "^1.1.2"
-tornado = "^6.0.4"
+numpy = "*"
+requests = "*"
+pandas = "*"
+tornado = "*"
 
 [tool.poetry.dev-dependencies]
-mock = "^4.0.2"
-pytest = "^6.1.0"
-pytest-cov = "^2.10.1"
+mock = "*"
+pytest = "*"
+pytest-cov = "*"
 
 [tool.poetry.extras]
 docs = ["sphinx==1.5.6", "recommonmark", "sphinx_rtd_theme", "sphinxcontrib-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,14 @@ name = "groclient"
 version = "1.0.0"
 description = "Python client library for accessing Gro Intelligence's agricultural data platform"
 authors = ["John Ward <john.ward@gro-intelligence.com>"]
+readme = "README.md"
+homepage = "https://www.gro-intelligence.com/products/gro-api"
+repository = "https://github.com/gro-intelligence/api-client"
+documentation = "https://developers.gro-intelligence.com/"
+packages = [ { include = "groclient" } ]
+
+[tool.poetry.scripts]
+gro_client = 'groclient.__main__:main'
 
 [tool.poetry.dependencies]
 python = ">=3.6.1,<4.0"
@@ -15,6 +23,9 @@ tornado = "^6.0.4"
 mock = "^4.0.2"
 pytest = "^6.1.0"
 pytest-cov = "^2.10.1"
+
+[tool.poetry.extras]
+docs = ["sphinx==1.5.6", "recommonmark", "sphinx_rtd_theme", "sphinxcontrib-versioning"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "groclient"
+version = "1.0.0"
+description = "Python client library for accessing Gro Intelligence's agricultural data platform"
+authors = ["John Ward <john.ward@gro-intelligence.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.6.1,<4.0"
+numpy = "^1.19.2"
+requests = "^2.24.0"
+pandas = "^1.1.2"
+tornado = "^6.0.4"
+
+[tool.poetry.dev-dependencies]
+mock = "^4.0.2"
+pytest = "^6.1.0"
+pytest-cov = "^2.10.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/gro-intelligence/api-client",
-    packages=setuptools.find_packages(),
-    python_requires=">=2.7.12, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    packages=['groclient'],
+    python_requires=">=3.6.1, <4",
     install_requires=requirements,
     extras_require={
         'docs': docs_requirements,

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.7
 
 branches:
@@ -16,7 +15,8 @@ build:
   cache_dir_list:
     - /root/.cache/pip
   ci:
-    - shippable_retry pip install .[test]
+    - shippable_retry pip install .
+    - shippable_retry pip install -r requirements-test.txt
     # Run doctests
     - python groclient/lib.py -v
     # Create folders for test and code coverage
@@ -29,9 +29,8 @@ build:
       --cov=groclient
       --cov-report=xml:shippable/codecoverage/coverage.xml
     - >
-      if [ "$SHIPPABLE_PYTHON_VERSION" == "3.7" ]; then
-        shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt && pytest api/client/samples/analogous_years/
-      fi;
+      shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
+      pytest api/client/samples/analogous_years/
   on_success:
     # Only build docs on the Python 2.7 run. It is unnecessary to run on both 2.x and 3.x - one or
     # the other should suffice. However, as of this writing

--- a/shippable.yml
+++ b/shippable.yml
@@ -16,24 +16,26 @@ build:
   cache_dir_list:
     - /root/.cache/pip
   ci:
-    - shippable_retry pip install .
-    - shippable_retry pip install -r requirements-test.txt
+    - shippable_retry pip install poetry
+    - shippable_retry poetry install
     # Run doctests
-    - python groclient/lib.py -v
+    - poetry run python groclient/lib.py -v
     # Create folders for test and code coverage
     - mkdir -p shippable/testresults
     - mkdir -p shippable/codecoverage
     # Run test and code coverage and output results to the right folder
     - >
-      pytest
+      poetry run pytest
       --junitxml=shippable/testresults/nosetests.xml
       --cov=groclient
       --cov-report=xml:shippable/codecoverage/coverage.xml
+    # - >
+    #   shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
+    #   pytest api/client/samples/analogous_years/
+    - echo $IS_RELEASE
+    - echo $BRANCH
     - >
-      shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
-      pytest api/client/samples/analogous_years/
-    - >
-      if [ "$IS_RELEASE" ] || [ "$BRANCH" == "development" ]; then
+      if [ $IS_RELEASE ] || [ $BRANCH == "development" ]; then
         poetry build &&
         poetry publish -r testpypi --username=__token__ --password="$PYPI_TOKEN"
       fi;
@@ -45,7 +47,7 @@ build:
     # an older 3.x version to the build matrix just to support docs.
     - >
       if [ "$SHIPPABLE_PYTHON_VERSION" == "2.7" ]; then
-        shippable_retry pip install .[docs] &&
+        shippable_retry poetry install -E docs &&
         git config --global user.email "api-documentation@gro-intelligence.com" &&
         git config --global user.name "Gro Intelligence" &&
         git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&

--- a/shippable.yml
+++ b/shippable.yml
@@ -31,28 +31,19 @@ build:
       --junitxml=shippable/testresults/nosetests.xml
       --cov=groclient
       --cov-report=xml:shippable/codecoverage/coverage.xml
-    # - >
-    #   shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
-    #   pytest api/client/samples/analogous_years/
+    - >
+      shippable_retry poetry run pip install -r api/client/samples/analogous_years/requirements.txt &&
+      poetry run pytest api/client/samples/analogous_years/
   on_success:
-    - echo $IS_RELEASE
-    - echo $BRANCH
-    - > # push to PyPI
-      if [ $IS_RELEASE ] || [ $BRANCH == "development" ]; then
+    - > # Build docs using sphinx and push to gh-pages
+      shippable_retry poetry install -E docs &&
+      git config --global user.email "api-documentation@gro-intelligence.com" &&
+      git config --global user.name "Gro Intelligence" &&
+      git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
+      ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; sphinx-versioning push -r development docs gh-pages .';
+    - > # push a beta build to PyPI when a PR is merged to development, or a release build when a release is tagged.
+      if [ $IS_RELEASE == "true" ] || [ $BRANCH == "development" ]; then
         poetry build &&
         poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
         poetry publish -r testpypi --username=__token__ --password="$PYPI_TOKEN"
-      fi;
-    # Only build docs on the Python 2.7 run. It is unnecessary to run on both 2.x and 3.x - one or
-    # the other should suffice. However, as of this writing
-    # https://github.com/sphinx-contrib/sphinxcontrib-versioning does not support the latest 3.x
-    # versions, which we do want to run unit tests on. That is why 2.x is used, rather than adding
-    # an older 3.x version to the build matrix just to support docs.
-    - >
-      if [ "$SHIPPABLE_PYTHON_VERSION" == "2.7" ]; then
-        shippable_retry poetry install -E docs &&
-        git config --global user.email "api-documentation@gro-intelligence.com" &&
-        git config --global user.name "Gro Intelligence" &&
-        git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
-        ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; sphinx-versioning push -r development docs gh-pages .';
       fi;

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,8 +8,10 @@ branches:
     - gh-pages
 
 env:
-  - GROAPI_TOKEN=dummytoken
-  - secure: 3t2LN1D8s4LDdgM1GZgGX9uLZa2l/LU92ByV3fyGI2b+qbhppZzhGTAClRSyHWFtLCRXRCxQRrJyP44ktsPTaN7cKaFKHX8iV22GI1LfXXL0n6fMwuJgxvqUO3plGHtC6aTQuYSVxVqdklcN8vyZR/wdS0jDKfTQF8RzOZmKRjQ0Je6za1FHE4Eyl88NXspMxv/g9ywfs3uTVKjpyPvQDvMk3h+6ZDrBr9L6KxXzu3XLxb9Tsu97WXKLXXPq6Cxww6bZFzUZPQLlox5ILvVIV4A642Ul9MJUToIYg7gyV+e64d3Lg/4SlnxmARDcndo79+lDIsSpbbRTfY99MxQs8BgrBeyIIghatWEfOSYBzWe6Z18ttyeTwA5bm5+tBx8qDgOUleHQWXmLz29Xmx6uq5PylgSYvJND1qDaxaws8J0mibf5mEnoUILYzyjN8TdlJHhs2/9IZvkrxqDb4Q7f+J3dYSF52JAkPJdWyKF4qQYgKCo6yKj7zCVSKqIwwss20zDBfBoFh52dquumwI9A8VHhHDXV3lyArGB3vA6jE1zznwK9B0WNmd2NOkrOCM1+ROUyoFeZfBsHb4hSZUUihUBqaxe6ihd+PRhlOxSuxwjlW8ftIL0wmHiB6YYjkmCkdiSKrDL3lTkX7tX+vq7uc/Fy4tjz2zoOw2nYxhLHjUw=
+  global:
+    - GROAPI_TOKEN: dummytoken
+    - secure: "3t2LN1D8s4LDdgM1GZgGX9uLZa2l/LU92ByV3fyGI2b+qbhppZzhGTAClRSyHWFtLCRXRCxQRrJyP44ktsPTaN7cKaFKHX8iV22GI1LfXXL0n6fMwuJgxvqUO3plGHtC6aTQuYSVxVqdklcN8vyZR/wdS0jDKfTQF8RzOZmKRjQ0Je6za1FHE4Eyl88NXspMxv/g9ywfs3uTVKjpyPvQDvMk3h+6ZDrBr9L6KxXzu3XLxb9Tsu97WXKLXXPq6Cxww6bZFzUZPQLlox5ILvVIV4A642Ul9MJUToIYg7gyV+e64d3Lg/4SlnxmARDcndo79+lDIsSpbbRTfY99MxQs8BgrBeyIIghatWEfOSYBzWe6Z18ttyeTwA5bm5+tBx8qDgOUleHQWXmLz29Xmx6uq5PylgSYvJND1qDaxaws8J0mibf5mEnoUILYzyjN8TdlJHhs2/9IZvkrxqDb4Q7f+J3dYSF52JAkPJdWyKF4qQYgKCo6yKj7zCVSKqIwwss20zDBfBoFh52dquumwI9A8VHhHDXV3lyArGB3vA6jE1zznwK9B0WNmd2NOkrOCM1+ROUyoFeZfBsHb4hSZUUihUBqaxe6ihd+PRhlOxSuxwjlW8ftIL0wmHiB6YYjkmCkdiSKrDL3lTkX7tX+vq7uc/Fy4tjz2zoOw2nYxhLHjUw="
+
 
 build:
   cache: true
@@ -32,14 +34,15 @@ build:
     # - >
     #   shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
     #   pytest api/client/samples/analogous_years/
+  on_success:
     - echo $IS_RELEASE
     - echo $BRANCH
-    - >
+    - > # push to PyPI
       if [ $IS_RELEASE ] || [ $BRANCH == "development" ]; then
         poetry build &&
+        poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
         poetry publish -r testpypi --username=__token__ --password="$PYPI_TOKEN"
       fi;
-  on_success:
     # Only build docs on the Python 2.7 run. It is unnecessary to run on both 2.x and 3.x - one or
     # the other should suffice. However, as of this writing
     # https://github.com/sphinx-contrib/sphinxcontrib-versioning does not support the latest 3.x

--- a/shippable.yml
+++ b/shippable.yml
@@ -9,6 +9,7 @@ branches:
 
 env:
   - GROAPI_TOKEN=dummytoken
+  - secure: 3t2LN1D8s4LDdgM1GZgGX9uLZa2l/LU92ByV3fyGI2b+qbhppZzhGTAClRSyHWFtLCRXRCxQRrJyP44ktsPTaN7cKaFKHX8iV22GI1LfXXL0n6fMwuJgxvqUO3plGHtC6aTQuYSVxVqdklcN8vyZR/wdS0jDKfTQF8RzOZmKRjQ0Je6za1FHE4Eyl88NXspMxv/g9ywfs3uTVKjpyPvQDvMk3h+6ZDrBr9L6KxXzu3XLxb9Tsu97WXKLXXPq6Cxww6bZFzUZPQLlox5ILvVIV4A642Ul9MJUToIYg7gyV+e64d3Lg/4SlnxmARDcndo79+lDIsSpbbRTfY99MxQs8BgrBeyIIghatWEfOSYBzWe6Z18ttyeTwA5bm5+tBx8qDgOUleHQWXmLz29Xmx6uq5PylgSYvJND1qDaxaws8J0mibf5mEnoUILYzyjN8TdlJHhs2/9IZvkrxqDb4Q7f+J3dYSF52JAkPJdWyKF4qQYgKCo6yKj7zCVSKqIwwss20zDBfBoFh52dquumwI9A8VHhHDXV3lyArGB3vA6jE1zznwK9B0WNmd2NOkrOCM1+ROUyoFeZfBsHb4hSZUUihUBqaxe6ihd+PRhlOxSuxwjlW8ftIL0wmHiB6YYjkmCkdiSKrDL3lTkX7tX+vq7uc/Fy4tjz2zoOw2nYxhLHjUw=
 
 build:
   cache: true
@@ -31,6 +32,11 @@ build:
     - >
       shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
       pytest api/client/samples/analogous_years/
+    - >
+      if [ "$IS_RELEASE" ] || [ "$BRANCH" == "development" ]; then
+        poetry build &&
+        poetry publish -r testpypi --username=__token__ --password="$PYPI_TOKEN"
+      fi;
   on_success:
     # Only build docs on the Python 2.7 run. It is unnecessary to run on both 2.x and 3.x - one or
     # the other should suffice. However, as of this writing

--- a/shippable.yml
+++ b/shippable.yml
@@ -40,7 +40,7 @@ build:
       git config --global user.email "api-documentation@gro-intelligence.com" &&
       git config --global user.name "Gro Intelligence" &&
       git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
-      ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; sphinx-versioning push -r development docs gh-pages .';
+      ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; poetry run sphinx-versioning push -r development docs gh-pages .';
     - > # push a beta build to PyPI when a PR is merged to development, or a release build when a release is tagged.
       if [ $IS_RELEASE == "true" ] || [ $BRANCH == "development" ]; then
         poetry build &&


### PR DESCRIPTION
This PR introduces the build tool [Poetry](https://python-poetry.org/) for managing dependencies and publishing the groclient package to PyPI.

1. This pyproject.toml file that poetry uses is the modern python replacement for setup.py (read: https://snarky.ca/what-the-heck-is-pyproject-toml/). So, all the project config stuff has been ported over to pyproject.toml instead. Setup.py can be deprecated except for the editable install shim in the above-mentioned post.
2. DROPPING PYTHON 2 & LEGACY `api.client` PACKAGE. All Python 2 users, having installed via git, can continue to do so by locking their installation command to the latest tag.

Testing:

```sh
$ poetry build
Building groclient (1.93.2b2)
  - Building sdist
  - Built groclient-1.93.2b2.tar.gz
  - Building wheel
  - Built groclient-1.93.2b2-py3-none-any.whl

$ poetry publish -r testpypi --username=__token__ --password="<pypi token>"
Publishing groclient (1.93.2b2) to testpypi
 - Uploading groclient-1.93.2b2-py3-none-any.whl 100%
 - Uploading groclient-1.93.2b2.tar.gz 100%

$ pip install --index-url https://test.pypi.org/simple/ groclient
```