### PR TITLE
CLEWS-32775 fix/workaround for `fetch() called on closed AsyncHTTPClient` errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.py[cod]
+venv

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -10,8 +10,6 @@ from groclient.constants import DATA_SERIES_UNIQUE_TYPES_ID
 
 MOCK_HOST = 'pytest.groclient.url'
 MOCK_TOKEN = 'pytest.groclient.token'
-PYTHON_VERSION = platform.python_version()
-API_CLIENT_VERSION = get_distribution('groclient').version
 
 LOOKUP_MAP = {
     'metrics': {},


### PR DESCRIPTION
#257 added a __del__ method to GroClient.

After this PR, we've noticed occasional, difficult-to-isolate/reproduce
bugs where GroClient.__del__ is called on objects that are still in use.
GroClient.__del__ includes _async_http_client.close(), which causes
subsequent uses of _async_http_client to raise RuntimeError("fetch()
called on closed AsyncHTTPClient").

FWIW, the spurious calls to __del__ seem occur when:
- GroClient is used in a Celery task
- the task also connects to databases (pandas.io.sql.read_sql_query, psychopg2)