### PR TITLE
use sphinx-versions to avoid unicode errors

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 sphinx==1.5.6
 recommonmark
 sphinx_rtd_theme
-sphinxcontrib-versioning
+sphinx-versions

--- a/shippable.yml
+++ b/shippable.yml
@@ -38,11 +38,18 @@ build:
     # https://github.com/sphinx-contrib/sphinxcontrib-versioning does not support the latest 3.x
     # versions, which we do want to run unit tests on. That is why 2.x is used, rather than adding
     # an older 3.x version to the build matrix just to support docs.
+    #
+    # 2020-10-21 jli: attempting to use sphinx-versions to workaround
+    # occasional unicode-related shippable build errors we're seeing w/
+    # sphinxcontrib-versioning.
+    #
+    # TODO(jli): surely these tools can work on more recent versions of Python?
+    # submit an upstream change.
     - >
       if [ "$SHIPPABLE_PYTHON_VERSION" == "2.7" ]; then
         shippable_retry pip install .[docs] &&
         git config --global user.email "api-documentation@gro-intelligence.com" &&
         git config --global user.name "Gro Intelligence" &&
         git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
-        ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; sphinx-versioning push -r development docs gh-pages .';
+        ssh-agent bash -c 'ssh-add /tmp/ssh/00_sub; sphinx-versions push -r development docs gh-pages .';
       fi;


### PR DESCRIPTION
We use sphinxcontrib-versioning to build the documentation on
developers.gro-intelligence.com. It hasn't been updated since 2016 and
doesn't work on latest versions of Python 3 we use in Shippable. So,
we're using Python 2 to build our documentation. Sometimes, this flakily
results in unexpected unicode-related errors (e.g.
https://app.shippable.com/github/gro-intelligence/api-client/runs/3833/1/console),
which blocks our ability to merge PRs.

This change switches to using sphinx-versions instead, a fork of
sphinxcontrib-versioning which has at least been updated since 2019 and
has some unicode-related bugfixes:
https://github.com/Smile-SA/sphinx-versions