### PR TITLE
CLEWS-33028: support list of ids in rank_series_by_source

### DIFF
--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -15,7 +15,6 @@ import logging
 import requests
 import time
 import platform
-import ast
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     # functools are native in Python 3.2.3+
@@ -423,7 +422,7 @@ def rank_series_by_source(access_token, api_host, selections_list):
 
     for series_key, series_by_source_id in series_map.items():
         series_without_source = {
-            type_id: ast.literal_eval(series_key.split('.')[idx])
+            type_id: json.loads(series_key.split('.')[idx])
             for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
             if type_id != 'source_id' and series_key.split('.')[idx] != 'None'
         }

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -15,6 +15,7 @@ import logging
 import requests
 import time
 import platform
+import ast
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     # functools are native in Python 3.2.3+
@@ -423,7 +424,7 @@ def rank_series_by_source(access_token, api_host, selections_list):
     for series_key, series_by_source_id in series_map.items():
         try:
             series_without_source = {
-                type_id: int(series_key.split('.')[idx])
+                type_id: ast.literal_eval(series_key.split('.')[idx])
                 for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
                 if type_id != 'source_id' and series_key.split('.')[idx] != 'None'
             }

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -422,17 +422,15 @@ def rank_series_by_source(access_token, api_host, selections_list):
         series_map[series_key][selection.get('source_id')] = selection
 
     for series_key, series_by_source_id in series_map.items():
-        try:
-            series_without_source = {
-                type_id: ast.literal_eval(series_key.split('.')[idx])
-                for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
-                if type_id != 'source_id' and series_key.split('.')[idx] != 'None'
-            }
-            source_ids = get_source_ranking(access_token,
-                                            api_host,
-                                            series_without_source)
-        except ValueError:
-            continue  # empty response
+        series_without_source = {
+            type_id: ast.literal_eval(series_key.split('.')[idx])
+            for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
+            if type_id != 'source_id' and series_key.split('.')[idx] != 'None'
+        }
+        source_ids = get_source_ranking(access_token,
+                                        api_host,
+                                        series_without_source)
+
         for source_id in source_ids:
             if source_id in series_by_source_id:
                 yield series_by_source_id[source_id]

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -411,7 +411,7 @@ def get_source_ranking(access_token, api_host, series):
 def rank_series_by_source(access_token, api_host, selections_list):
     series_map = OrderedDict()
     for selection in selections_list:
-        series_key = '.'.join([str(selection.get(type_id))
+        series_key = '.'.join([json.dumps(selection.get(type_id))
                                for type_id in DATA_SERIES_UNIQUE_TYPES_ID
                                if type_id != 'source_id'])
         if series_key not in series_map:

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -424,7 +424,7 @@ def rank_series_by_source(access_token, api_host, selections_list):
         series_without_source = {
             type_id: json.loads(series_key.split('.')[idx])
             for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
-            if type_id != 'source_id' and series_key.split('.')[idx] != 'None'
+            if type_id != 'source_id' and series_key.split('.')[idx] != 'null'
         }
         source_ids = get_source_ranking(access_token,
                                         api_host,

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -315,23 +315,23 @@ def test_rank_series_by_source(mock_requests_get):
         'end_date': '2020-05-01',
         'metadata': {'historical': True}
     }
-
-    partial_selections = {
+    # input selection should allow a list of ids
+    partial_selection = {
         'metric_id': 2540047,
         'item_id': 1457,
-        'region_id': 13474
+        'region_id': [13474,13475]
     }
 
     expected = [
         full_data_series,
-        dict_assign(partial_selections, 'source_id', mock_return[0]),
-        dict_assign(partial_selections, 'source_id', mock_return[1]),
-        dict_assign(partial_selections, 'source_id', mock_return[2])
+        dict_assign(partial_selection, 'source_id', mock_return[0]),
+        dict_assign(partial_selection, 'source_id', mock_return[1]),
+        dict_assign(partial_selection, 'source_id', mock_return[2])
     ]
     for idx, series in enumerate(lib.rank_series_by_source(MOCK_TOKEN,
                                                            MOCK_HOST,
                                                            [full_data_series,
-                                                            partial_selections])):
+                                                            partial_selection])):
         assert series == expected[idx]
 
 


### PR DESCRIPTION
**Issue**
Right now when passing queries with list of ids into rank_series_by_source(), it returns empty []
It's throwing `ValueError` from https://github.com/gro-intelligence/api-client/blob/development/groclient/lib.py#L426

The bug was introduced in https://github.com/gro-intelligence/api-client/pull/253/files 
that implementation only handles the case when selection includes single id.

**Solution**
parse series key with ast.literal_eval(), which should handle both single id and list of ids

**Testing**
Tested locally with Raphael's code, it should return ranked series now
```
client = GroClient(API_HOST, ACCESS_TOKEN)

region_id = 1215
item_id = 274
metric_id = 570001
regions = [
    r['id'] for r in client.get_descendant_regions(region_id, 4, include_historical=False, include_details=False)]

query = [{
    "metric_id": metric_id,
    "region_id": regions,
    "item_id": item_id, }]

res = list(client.rank_series_by_source(query))
print(res)
```

```
{'metric_id': 570001, 'item_id': 274, 'region_id': [13051, 13052, 13053, 13054, 13055, 13056, 13057, 13058, 13059, 13060, 13061, 13062, 13063, 13064, 13065, 13066, 13067, 13068, 13069, 13070, 13071, 13072, 13073, 13074, 13075, 13076, 13077, 13078, 13079, 13080, 13081, 13082, 13083, 13084, 13085, 13086, 13087, 13088, 13089, 13090, 13091, 13092, 13093, 13094, 13095, 13096, 13097, 13098, 13099, 13100, 13101], 'source_id': 25}]
```
