### PR TITLE
fix deprecated usage of `warn`

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -68,12 +68,12 @@ class GroClient(object):
             self._async_http_client = AsyncHTTPClient()
             self._ioloop = IOLoop()
         except Exception as e:
-            self._logger.warn(
+            self._logger.warning(
                 "Unable to initialize an event loop. Async methods disabled."
             )
             self._async_http_client = None
             self._ioloop = None
-        
+
     def __del__(self):
         self._async_http_client.close()
         self._ioloop.stop()
@@ -1080,7 +1080,7 @@ class GroClient(object):
         try:
             return self.get_df(index_by_series=True).loc[[tuple(entity_ids)], :]
         except KeyError:
-            self._logger.warn("GDH returned no data")
+            self._logger.warning("GDH returned no data")
             return pandas.DataFrame()
 
     def get_data_series_list(self):


### PR DESCRIPTION
Previously, the code was generating a DeprecationWarnings about our
usage of logging.Logger.warn, for example when running pytest:

======================== warnings summary ========================
groclient/client_test.py::GroClientTests::test_GDH
  /Users/johnli/src/api-client/groclient/client.py:1083: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._logger.warn("GDH returned no data")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 63 passed, 1 warning in 4.24s ========================