### PR TITLE
CLEWS-33028 : add try/catch back rank_series_by_source() to handle "no content" response

### DIFF
--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -426,9 +426,13 @@ def rank_series_by_source(access_token, api_host, selections_list):
             for idx, type_id in enumerate(DATA_SERIES_UNIQUE_TYPES_ID)
             if type_id != 'source_id' and series_key.split('.')[idx] != 'null'
         }
-        source_ids = get_source_ranking(access_token,
-                                        api_host,
-                                        series_without_source)
+        try:
+            source_ids = get_source_ranking(access_token,
+                                            api_host,
+                                            series_without_source)
+        # Catch "no content" response from get_source_ranking()
+        except ValueError:
+            continue  # empty response
 
         for source_id in source_ids:
             if source_id in series_by_source_id:


### PR DESCRIPTION
**Problem**:
Introduced by this commit https://github.com/gro-intelligence/api-client/pull/270/commits/3d0d9c59e89c37e66cbcf35fb1672cf541547b89
i shouldn't completely remove the try/catch, get_source_ranking() would return 204 (no content) of there's no data available . Removing that is causing JSONdecode error 

**Solution**:
Adding try/catch back to wrap get_source_ranking() function within rank_series_by_source()

**Testing**:
run this sample code locally, it should return empty array 

```
client = GroClient(API_HOST, ACCESS_TOKEN)
    fr5 = [r['id'] for r in client.get_descendant_regions(1070, 5, include_historical=False, include_details=False)]
    results = client.rank_series_by_source([{'region_id': fr5, 'metric_id': 570001, 'item_id': 274, 'frequency_id': 9, 'start_date': '2000-01-01'}])
    print(list(results))
```
