### PR TITLE
add generic get_descendant function

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -705,7 +705,11 @@ class GroClient(object):
         distance=None,
         include_details=True,
     ):
-        """Look up details of all entities level contained by an item/metric/regions.
+        """Given an item/metric/region id return all ids contained in the graph, and their relative details
+
+        Similar to :meth:~.get_descendant_regions, but also works on items and metrics. This method has 
+        a distance parameter (which returns all nested child entities) instead of a descendant_level 
+        parameter (which only returns child entities at a given depth/level).
 
         Parameters
         ----------
@@ -728,11 +732,11 @@ class GroClient(object):
                 [{
                     'id': 134,
                     'name': 'Cattle hides, wet-salted',
-                    'definition': 'Hides and skins of domesticated cattle—animals ...',
+                    'definition': 'Hides and skins of domesticated cattle-animals ...',
                 } , {
                     'id': 382,
                     'name': 'Calf skins, wet-salted',
-                    'definition': 'Wet-salted hides and skins of calves—animals of ...'
+                    'definition': 'Wet-salted hides and skins of calves-animals of ...'
                 }, ...]
 
             See output of :meth:`~.lookup`

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -707,8 +707,6 @@ class GroClient(object):
     ):
         """Look up details of all entities level contained by an item/metric/regions.
 
-        Given any region by id, get all the descendant regions that are of the specified level.
-
         Parameters
         ----------
         entity_type : { 'metrics', 'items', 'regions' }

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -705,7 +705,8 @@ class GroClient(object):
         distance=None,
         include_details=True,
     ):
-        """Given an item/metric/region id return all ids contained in the graph, and their relative details
+        """Given an item, metric or region, returns all its descendants i.e. 
+        entities that are "contained" in the given entity
 
         Similar to :meth:~.get_descendant_regions, but also works on items and metrics. This method has 
         a distance parameter (which returns all nested child entities) instead of a descendant_level 

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -698,6 +698,58 @@ class GroClient(object):
         """
         return lib.get_geojson(self.access_token, self.api_host, region_id, zoom_level)
 
+    def get_descendant(
+        self,
+        entity_type,
+        entity_id,
+        distance=None,
+        include_details=True,
+    ):
+        """Look up details of all entities level contained by an item/metric/regions.
+
+        Given any region by id, get all the descendant regions that are of the specified level.
+
+        Parameters
+        ----------
+        entity_type : { 'metrics', 'items', 'regions' }
+        entity_id : integer
+        distance: integer, optional
+            Return all entity contained to entity_id at maximum distance.
+            If not provided, get all descendants.
+        include_details : boolean, optional
+            True by default. Will perform a lookup() on each descendant  to find name,
+            definition, etc. If this option is set to False, only ids of descendant
+            entities will be returned, which makes execution significantly faster.
+
+        Returns
+        -------
+        list of dicts
+
+            Example::
+
+                [{
+                    'id': 134,
+                    'name': 'Cattle hides, wet-salted',
+                    'definition': 'Hides and skins of domesticated cattle—animals ...',
+                } , {
+                    'id': 382,
+                    'name': 'Calf skins, wet-salted',
+                    'definition': 'Wet-salted hides and skins of calves—animals of ...'
+                }, ...]
+
+            See output of :meth:`~.lookup`
+
+        """
+        return lib.get_descendant(
+            self.access_token,
+            self.api_host,
+            entity_type,
+            entity_id,
+            distance,
+            include_details,
+        )
+
+
     def get_descendant_regions(
         self,
         region_id,

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -87,6 +87,26 @@ def mock_get_geojsons(access_token, api_host, region_id, descendant_level, zoom_
     ]
 
 
+def mock_get_descendant(
+    access_token,
+    api_host,
+    entity_type,
+    entity_id,
+    distance,
+    include_details,
+):
+
+    childs = [
+            child
+            for child in mock_entities[entity_type].values()
+            if 119 in child["belongsTo"]
+        ]
+    if include_details:
+        return childs
+    else:
+        return [{"id": child["id"]} for child in childs]
+
+
 def mock_get_descendant_regions(
     access_token,
     api_host,
@@ -193,6 +213,7 @@ def mock_get_data_points(access_token, api_host, **selections):
 @patch("groclient.lib.get_geo_centre", MagicMock(side_effect=mock_get_geo_centre))
 @patch("groclient.lib.get_geojsons", MagicMock(side_effect=mock_get_geojsons))
 @patch("groclient.lib.get_geojson", MagicMock(side_effect=mock_get_geojson))
+@patch("groclient.lib.get_descendant", MagicMock(side_effect=mock_get_descendant))
 @patch(
     "groclient.lib.get_descendant_regions",
     MagicMock(side_effect=mock_get_descendant_regions),
@@ -278,6 +299,13 @@ class GroClientTests(TestCase):
         self.assertTrue("type" in geojson["geometries"][0])
         self.assertTrue("coordinates" in geojson["geometries"][0])
         self.assertTrue(geojson["geometries"][0]['coordinates'][0][0][0] == [-38, -4])
+
+    def test_get_descendant(self):
+        self.assertTrue("name" in self.client.get_descendant('metrics', 119)[0])
+        self.assertTrue(
+            "name"
+            not in self.client.get_descendant('metrics', 119, include_details=False)[0]
+        )
 
     def test_get_descendant_regions(self):
         self.assertTrue("name" in self.client.get_descendant_regions(1215)[0])

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -585,6 +585,26 @@ def get_geojson(access_token, api_host, region_id, zoom_level):
         return json.loads(region['geojson'])
 
 
+def get_descendant(access_token, api_host, entity_type, entity_id, distance=None,
+                   include_details=True):
+    url = '/'.join(['https:', '', api_host, 'v2/{}/contains'.format(entity_type)])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = {'ids': [entity_id]}
+    if distance:
+        params['distance'] = distance
+    else:
+        params['distance'] = -1
+
+    resp = get_data(url, headers, params)
+    descendant_entity_ids = resp.json()['data'][str(entity_id)]
+
+    if include_details:
+        entity_details = lookup(access_token, api_host, entity_type, descendant_entity_ids)
+        return [entity_details[str(child_entity_id)] for child_entity_id in descendant_entity_ids]
+
+    return [{'id': descendant_entity_id} for descendant_entity_id in descendant_entity_ids]
+
+
 def get_descendant_regions(access_token, api_host, region_id,
                            descendant_level=None, include_historical=True, include_details=True):
     url = '/'.join(['https:', '', api_host, 'v2/regions/contains'])

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -355,30 +355,30 @@ def lookup_mock(MOCK_TOKEN, MOCK_HOST, entity_type, entity_ids):
 
 @mock.patch('groclient.lib.lookup')
 @mock.patch('requests.get')
-def test_descendant_regions(mock_requests_get, lookup_mocked):
+def test_get_descendant(mock_requests_get, lookup_mocked):
     mock_requests_get.return_value.json.return_value = {'data': {'4': [1, 2, 3]}}
     mock_requests_get.return_value.status_code = 200
     lookup_mocked.side_effect = lookup_mock
 
-    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4) == [
-        {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'def': 'def1'},
-        {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'def': 'def2'},
-        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 4) == [
+        {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'definition': 'def1'},
+        {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'definition': 'def2'},
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'}
     ]
     
-    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, include_details=True) == [
-        {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'def': 'def1'},
-        {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'def': 'def2'},
-        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'metrics', 4, include_details=True) == [
+        {'id': 1, 'name': 'metric 1', 'contains': [], 'belongsTo': [3], 'definition': 'def1'},
+        {'id': 2, 'name': 'metric 2', 'contains': [], 'belongsTo': [3], 'definition': 'def2'},
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'}
     ]
 
-    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, include_details=False) == [
-        {'id': 1}, {'id': 2}, {'id': 4}
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 4, include_details=False) == [
+        {'id': 1}, {'id': 2}, {'id': 3}
     ]
 
     mock_requests_get.return_value.json.return_value = {'data': {'4': [3]}}
-    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, distance=1) == [
-        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 4, distance=1) == [
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'}
     ]
 
     

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -12,8 +12,18 @@ MOCK_HOST = 'pytest.groclient.url'
 MOCK_TOKEN = 'pytest.groclient.token'
 
 LOOKUP_MAP = {
-    'metrics': {},
-    'items': {},
+    'metrics': {
+        '1': {'id': 1, 'name': 'metric 1', 'contains': [], 'belongsTo': [3], 'definition': 'def1'},
+        '2': {'id': 2, 'name': 'metric 2', 'contains': [], 'belongsTo': [3], 'definition': 'def2'},
+        '3': {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'},
+        '4': {'id': 4, 'name': 'ancestor', 'contains': [3], 'belongsTo': [], 'definition': 'def4'}
+    },
+    'items': {
+        '1': {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'definition': 'def1'},
+        '2': {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'definition': 'def2'},
+        '3': {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'},
+        '4': {'id': 4, 'name': 'ancestor', 'contains': [3], 'belongsTo': [], 'definition': 'def4'}
+    },
     'regions': {
         '1': {'id': 1, 'name': 'region 1', 'contains': [], 'belongsTo': [3], 'historical': True},
         '2': {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False},
@@ -342,6 +352,36 @@ def lookup_mock(MOCK_TOKEN, MOCK_HOST, entity_type, entity_ids):
         return {str(entity_id): LOOKUP_MAP[entity_type][str(entity_id)]
                 for entity_id in entity_ids}
 
+
+@mock.patch('groclient.lib.lookup')
+@mock.patch('requests.get')
+def test_descendant_regions(mock_requests_get, lookup_mocked):
+    mock_requests_get.return_value.json.return_value = {'data': {'4': [1, 2, 3]}}
+    mock_requests_get.return_value.status_code = 200
+    lookup_mocked.side_effect = lookup_mock
+
+    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4) == [
+        {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'def': 'def1'},
+        {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'def': 'def2'},
+        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    ]
+    
+    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, include_details=True) == [
+        {'id': 1, 'name': 'item 1', 'contains': [], 'belongsTo': [3], 'def': 'def1'},
+        {'id': 2, 'name': 'item 2', 'contains': [], 'belongsTo': [3], 'def': 'def2'},
+        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    ]
+
+    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, include_details=False) == [
+        {'id': 1}, {'id': 2}, {'id': 4}
+    ]
+
+    mock_requests_get.return_value.json.return_value = {'data': {'4': [3]}}
+    assert lib.get_descendant_regions(MOCK_TOKEN, MOCK_HOST, 4, distance=1) == [
+        {'id': 3, 'name': 'parent', 'contains': [], 'belongsTo': [4], 'def': 'def3'}
+    ]
+
+    
 
 @mock.patch('groclient.lib.lookup')
 @mock.patch('requests.get')


### PR DESCRIPTION
Added a more function which returns all child included in an entity_id. 
The function _get_descendant_regions_ works specifically only for regions, _get_descendant_ work also for items and metrics

Script to test it: 
````
import os
from api.client.gro_client import GroClient
client = GroClient('api.gro-intelligence.com', os.environ['GROAPI_TOKEN'])

item_id = list(client.search_and_lookup('items', 'Fruits'))[0]
print('name: {}, id: {}'.format(item_id['name'], item_id['id']))
res = client.get_descendant('items', item_id['id'], include_details=True, distance=1)
print('Directly include in {}: '.format(item_id['name']) + ' ,'.join([item['name'] for item in res]))
res = client.get_descendant('items', item_id['id'], include_details=False)
print('Total items included in {}: {}'.format(item_id['name'], len(res)))

metric_id = list(client.search_and_lookup('metrics', 'NDVI'))[0]
print('name: {}, id: {}'.format(metric_id['name'], metric_id['id']))
res = client.get_descendant('metrics', metric_id['id'], include_details=True, distance=1)
print('Directly include in {}: '.format(metric_id['name']) + ' ,'.join([metr['name'] for metr in res]))
res = client.get_descendant('metrics', metric_id['id'], include_details=False)
print('Total items included in {}: {}'.format(metric_id['name'], len(res)))


output: 


name: Fruits, id: 18063
Directly include in Fruits: Fruit, dried, NES ,Fruit, fresh, NES ,Tropical fruit, fresh, NES ,Fruits, NES ,Fruit crops ,Tropical and subtropical fruit ,Tropical and subtropical fruit, NES ,Temperate fruits ,Produce, packaged
Total items included in Fruits: 2871
name: Vegetation, id: 103
Directly include in Vegetation: Vegetation Indices ,Vegetation Anomalies ,Biomass Burned ,Burned Area
Total items included in Vegetation: 10
```