### PR TITLE
add warning about `api` modules being deprecated (CLEWS-25136)

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -14,5 +14,5 @@ logger.warning('''
     And replace any other imports from `api.client.*` with imports from
     `groclient.*` instead.
 
-    Please reach out to dev@gro-intelligence.com if you need any help!
+    Please reach out to api-support@gro-intelligence.com if you need any help!
 ''')

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,18 @@
+from groclient.lib import get_default_logger
+
+logger = get_default_logger()
+logger.warning('''
+    Deprecation Warning!
+
+    You are importing modules from deprecated `api` module to access Gro
+    Intelligence's API.  Please update your code to import from the `groclient`
+    module instead.  The `api` module will be removed by 2021-03-31.
+
+    Replace: from api.client.gro_client import GroClient
+       with: from groclient import GroClient
+
+    And replace any other imports from `api.client.*` with imports from
+    `groclient.*` instead.
+
+    Please reach out to dev@gro-intelligence.com if you need any help!
+''')


### PR DESCRIPTION
This will generate a logged warning whenever anyone imports from the old modules (`api`, `api.client`, etc).

The message:
- explains to the user how to change their code to import from the new `groclient` module.
- says we'll remove the old `api` modules completely by 2021-03-31 (~6 months from now).
- says the user can reach out to dev@gro-intelligence.com for help.

Here's what it looks like when you run code that uses the old module names:

```python
import os
from api.client.gro_client import GroClient

client = GroClient("api.gro-intelligence.com", os.environ["GROAPI_TOKEN"])
print(
    client.get_data_points(
        **{
            "metric_id": 170037,
            "item_id": 270,
            "region_id": 1215,
            "source_id": 32,
            "frequency_id": 9,
            "start_date": "2019-01-01",
            "end_date": "2019-12-31",
        }
    )
)
```

```sh
% python clienttest_deprecated.py

    Deprecation Warning!

    You are importing modules from deprecated `api` module to access Gro
    Intelligence's API.  Please update your code to import from the `groclient`
    module instead.  The `api` module will be removed by 2021-03-31.

    Replace: from api.client.gro_client import GroClient
       with: from groclient import GroClient

    And replace any other imports from `api.client.*` with imports from
    `groclient.*` instead.

    Please reach out to dev@gro-intelligence.com if you need any help!

[{'start_date': '2019-01-01T00:00:00.000Z', 'end_date': '2019-12-31T00:00:00.000Z', 'value': 46.6475202914482, 'unit_id': 287, 'metadata': {}, 'input_unit_id': 287, 'input_unit_scale': 1, 'reporting_date': None, 'metric_id': 170037, 'item_id': 270, 'region_id': 1215, 'partner_region_id': 0, 'frequency_id': 9}]
```