### PR TITLE
CLEWS-33473 convert metadata.confInterval into snake_case

### DIFF
--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -503,6 +503,9 @@ def list_of_series_to_single_series(series_list, add_belongs_to=False, include_h
                 'frequency_id': series['series'].get('frequencyId', None)
                 # 'source_id': series['series'].get('sourceId', None), TODO: add source to output
             }
+            if formatted_point['metadata'].get('confInterval') is not None:
+                formatted_point['metadata']['conf_interval'] = formatted_point['metadata'].pop('confInterval')
+
             if add_belongs_to:
                 # belongs_to is consistent with the series the user requested. So if an
                 # expansion happened on the server side, the user can reconstruct what

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -220,7 +220,7 @@ def test_list_of_series_to_single_series():
          'end_date': '2003-12-31',
          'value': 123,
          'unit_id': 15,
-         'metadata': {'confInterval': 2},
+         'metadata': {'conf_interval': 2},
          'input_unit_id': 15,
          'input_unit_scale': 1,
          'reporting_date': None,


### PR DESCRIPTION
We are going to remove the redundant attribute 'conf_interval' in v2/data, so that the endpoint is always using camelcase if responseType is set to 'list_of_series'. Updated `lib.list_of_series_to_single_series()` to convert the format of metadata.
https://bitbucket.org/grointelligence/gro/pull-requests/18324/clews-33473-remove-metadataconf_interval/diff