### PR TITLE
disabling Shippable on gh-pages step 1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ html_static_path = ['_static', '_images']
 master_doc = 'index'
 
 # Do not delete these files:
-scv_grm_exclude = ('README.md', '.gitignore', '.nojekyll', 'CNAME')
+scv_grm_exclude = ('README.md', '.gitignore', '.nojekyll', 'CNAME', 'shippable.yml*')
 scv_show_banner = True
 scv_banner_main_ref = 'development'
 scv_root_ref = 'development'

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,10 +3,6 @@ language: python
 python:
   - 3.7
 
-branches:
-  except:
-    - gh-pages
-
 env:
   global:
     - GROAPI_TOKEN=dummytoken


### PR DESCRIPTION
Shippable keeps running (and failing) on the gh-pages branch
unnecessarily. We need to add a shippable.yml file to the branch to
disable Shippable. But first, we need to keep our docs automation to not
remove the file automatically.

Notice how all shippable builds on `gh-pages` fail: https://app.shippable.com/github/gro-intelligence/api-client/dashboard/history
Step 2 is here: #289 