### PR TITLE
disabling Shippable on gh-pages: step 2

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,16 @@
+# This disables Shippable for gh-pages.
+# 
+# It's not sufficient to specify this in the main branch's shippable.yml since
+# Shippable only looks at each branch's shippable.yml file:
+# http://docs.shippable.com/ci/specify-branches/
+#
+# We use a wildcard instead of 'gh-pages' because branches of gh-pages also
+# shouldn't have Shippable be triggered. (This should be rare, as changes to
+# gh-pages should be automated, but it occasionally happens.)
+# 
+# Using the wildcard here doesn't disable shippable for other branches, since
+# Shippable uses each branch's own shippable.yml
+
+branches:
+  except:
+    - '*'


### PR DESCRIPTION
Adds a shippable.yml to the gh-pages branch to disable Shippable on this branch.

This should be merged after step 1 (otherwise, this file will be automatically removed when sphinx-versioning updates the gh-pages branch). Step 1 is here: #288 