### PR TITLE
similar regions: improve for multiple runs on same instance

### DIFF
--- a/api/client/samples/similar_regions/example.ipynb
+++ b/api/client/samples/similar_regions/example.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "metadata": {
     "scrolled": false
    },
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 8,
    "metadata": {
     "scrolled": false
    },
@@ -83,18 +83,18 @@
      "output_type": "stream",
      "text": [
       "Districts similar to Napa in Oceania:\n",
-      "{'rank': 0, 'id': 136969, 'name': 'Napa', 'dist': 3.650024149988857e-08, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 1, 'id': 136984, 'name': 'Santa Clara', 'dist': 0.3622068331506979, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 2, 'id': 136990, 'name': 'Sonoma', 'dist': 0.3825601491958035, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 3, 'id': 136958, 'name': 'Lake', 'dist': 0.44251654494610837, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 4, 'id': 136942, 'name': 'Alameda', 'dist': 0.4686833468072968, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 5, 'id': 136968, 'name': 'Monterey', 'dist': 0.5148075072128724, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 6, 'id': 136946, 'name': 'Calaveras', 'dist': 0.573670342754695, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 7, 'id': 135463, 'name': 'Bahçe', 'dist': 0.5824937133254506, 'parent': {'id': 12890, 'name': 'Osmaniye'}, 'grand_parent': {'id': 1205, 'name': 'Turkey'}}\n",
-      "{'rank': 8, 'id': 136993, 'name': 'Tehama', 'dist': 0.6056198547178832, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 9, 'id': 136983, 'name': 'Santa Barbara', 'dist': 0.6128306994977581, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "CPU times: user 1.76 s, sys: 24.3 ms, total: 1.78 s\n",
-      "Wall time: 4.42 s\n"
+      "{'rank': 0, 'id': 102852, 'name': 'Upper Hunter Shire', 'dist': 1.0172970855301788, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 1, 'id': 102739, 'name': 'Dungog', 'dist': 1.0799373298855242, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 2, 'id': 100022537, 'name': 'Indigo', 'dist': 1.0809634582364187, 'parent': {'id': 10180, 'name': 'Victoria'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 3, 'id': 100022487, 'name': 'Mid-Western Regional', 'dist': 1.111684988763541, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 4, 'id': 100022557, 'name': 'Murrindindi', 'dist': 1.1134563951018985, 'parent': {'id': 10180, 'name': 'Victoria'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 5, 'id': 103807, 'name': 'Wodonga', 'dist': 1.1182429545534052, 'parent': {'id': 10180, 'name': 'Victoria'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 6, 'id': 100022478, 'name': 'Greater Hume Shire', 'dist': 1.1264457571861786, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 7, 'id': 100022464, 'name': 'Bathurst Regional', 'dist': 1.1310078670706942, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 8, 'id': 102859, 'name': 'Walcha', 'dist': 1.1381737030024375, 'parent': {'id': 10174, 'name': 'New South Wales'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "{'rank': 9, 'id': 100022567, 'name': 'Towong', 'dist': 1.1402392070557508, 'parent': {'id': 10180, 'name': 'Victoria'}, 'grand_parent': {'id': 1013, 'name': 'Australia'}}\n",
+      "CPU times: user 794 ms, sys: 22.3 ms, total: 817 ms\n",
+      "Wall time: 3.48 s\n"
      ]
     }
    ],
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {
     "scrolled": false
    },
@@ -127,18 +127,18 @@
      "output_type": "stream",
      "text": [
       "Districts similar to Napa in Ethiopia:\n",
-      "{'rank': 0, 'id': 136969, 'name': 'Napa', 'dist': 3.650024149988857e-08, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 1, 'id': 136984, 'name': 'Santa Clara', 'dist': 0.3622068331506979, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 2, 'id': 136990, 'name': 'Sonoma', 'dist': 0.3825601491958035, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 3, 'id': 136958, 'name': 'Lake', 'dist': 0.44251654494610837, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 4, 'id': 136942, 'name': 'Alameda', 'dist': 0.4686833468072968, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 5, 'id': 136968, 'name': 'Monterey', 'dist': 0.5148075072128724, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 6, 'id': 136946, 'name': 'Calaveras', 'dist': 0.573670342754695, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 7, 'id': 135463, 'name': 'Bahçe', 'dist': 0.5824937133254506, 'parent': {'id': 12890, 'name': 'Osmaniye'}, 'grand_parent': {'id': 1205, 'name': 'Turkey'}}\n",
-      "{'rank': 8, 'id': 136993, 'name': 'Tehama', 'dist': 0.6056198547178832, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "{'rank': 9, 'id': 136983, 'name': 'Santa Barbara', 'dist': 0.6128306994977581, 'parent': {'id': 13055, 'name': 'California'}, 'grand_parent': {'id': 1215, 'name': 'United States'}}\n",
-      "CPU times: user 1.84 s, sys: 8.11 ms, total: 1.84 s\n",
-      "Wall time: 4.5 s\n"
+      "{'rank': 0, 'id': 142811, 'name': 'Guji', 'dist': 1.2340454927482767, 'parent': {'id': 10925, 'name': 'Oromia'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 1, 'id': 115015, 'name': 'Eastern', 'dist': 1.397348519836437, 'parent': {'id': 10928, 'name': 'Tigray'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 2, 'id': 114979, 'name': 'Borena', 'dist': 1.494617589255949, 'parent': {'id': 10925, 'name': 'Oromia'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 3, 'id': 114978, 'name': 'Bale', 'dist': 1.5501842888658484, 'parent': {'id': 10925, 'name': 'Oromia'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 4, 'id': 114991, 'name': 'Liben', 'dist': 1.560802559811437, 'parent': {'id': 10926, 'name': 'Somali'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 5, 'id': 142822, 'name': 'Alaba', 'dist': 1.562030449923342, 'parent': {'id': 10927, 'name': 'Southern Nations, Nationalities and Peoples'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 6, 'id': 142824, 'name': 'South East', 'dist': 1.5929028959505167, 'parent': {'id': 10928, 'name': 'Tigray'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 7, 'id': 142823, 'name': \"Segen Peoples'\", 'dist': 1.6533758665988152, 'parent': {'id': 10927, 'name': 'Southern Nations, Nationalities and Peoples'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 8, 'id': 142806, 'name': 'Hareri', 'dist': 1.6692446182143326, 'parent': {'id': 10924, 'name': 'Hareri'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "{'rank': 9, 'id': 114981, 'name': 'East Shewa', 'dist': 1.6716251673952278, 'parent': {'id': 10925, 'name': 'Oromia'}, 'grand_parent': {'id': 1065, 'name': 'Ethiopia'}}\n",
+      "CPU times: user 1 s, sys: 32.4 ms, total: 1.03 s\n",
+      "Wall time: 3.71 s\n"
      ]
     }
    ],

--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -444,8 +444,9 @@ class SimilarRegion(object):
         self._logger.warning("Getting data series for {} regions in {} batch(es) for property {}".
                           format(n_reg, n_queries, prop_name))
         load_bar = tqdm(total=n_reg)
-        # Sending out all queries
-        self.client.batch_async_get_data_points(queries, map_result=map_response)
+        # Sending out all queries -- use fresh client instance to avoid mixing async connection pools between runs
+        data_client = GroClient(API_HOST, ACCESS_TOKEN)
+        data_client.batch_async_get_data_points(queries, map_result=map_response)
         load_bar.close()
         data_counters[data_counters == 0] = np.nan # avoid division by zero warning, where no data
         valid_data = valid_data/data_counters

--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -150,11 +150,11 @@ class SimilarRegion(object):
         self._logger.info("Constructing BallTrees...")
         self.metric_object = DistanceMetric.get_metric('pyfunc', **{'func':dist_function})
         self.ball = BallTree(self.data, metric=self.metric_object, leaf_size=2)
+        # TODO: don't reset the following dicts, keep ball trees and regions keyed by (search_region, level) instead of
+        # only level for more reuse
         self.balls_on_level = {}
         self.regions_on_level = {}
-        # separate ball trees to process requests on givel level
-        # shouldn't generally make separate data copies since region_id's are organized with countries < provinces < districts
-        # so data for each level should be continuous arrays
+        self.already_built = set()
         for level in region_levels:
             self.regions_on_level[level] = [r for r in self.available_regions if self.region_info[r]['level']==level]
             level_data = self.data[[self.region_index[r] for r in self.regions_on_level[level]],:]


### PR DESCRIPTION
- use correct ball tree in memory  for multiple runs: ball tree is only saved by level so the wrong tree can be used if we keep the same level and change different search_regions. This is a quick fix. Added TODO to make it more efficient

- use a fresh async batch for each build(): clients are very lightweight so this doesn't cost anything but avoids confusing async log messages due to reusing connection pool and queue from previous runs