### PR TITLE
Add CI checks for docs building cleanly

### DIFF
--- a/docs/modeling-resources.rst
+++ b/docs/modeling-resources.rst
@@ -164,7 +164,7 @@ NOTE: Our "beta" models have run for less than one full season. At this stage, e
 Radio Frequency Interference Effects On SMOS
 ============================================
 
-The attached document details the effect that Radio Frequency Interference (RFI) has on the soil moisture source `SMOS <https://app.gro-intelligence.com/#/dictionary/sources/43>`_: `radio-frequency-interference-smos.pdf <https://github.com/gro-intelligence/api-client/wiki/radio-frequency-interference-smos.pdf>`_
+The attached document details the effect that Radio Frequency Interference (RFI) has on the soil moisture source `SMOS <https://app.gro-intelligence.com/dictionary/sources/43>`_: `radio-frequency-interference-smos.pdf <https://github.com/gro-intelligence/api-client/wiki/radio-frequency-interference-smos.pdf>`_
 
 TRMM and GPM spatial extents
 ============================

--- a/shippable.yml
+++ b/shippable.yml
@@ -33,11 +33,14 @@ build:
       shippable_retry pip install -r api/client/samples/analogous_years/requirements.txt &&
       poetry run pytest api/client/samples/analogous_years/
   on_success:
+    # Ensure latest docs build without warnings or errors.
+    - >
+      shippable_retry poetry install -E docs &&
+      poetry run sphinx-build -W --keep-going docs docs/_build/html
     # Build docs and push to gh-pages.
     # Note: git remote set-url is for setting a git url instead of an https
     # one, which is needed so Shippable can be authenticated to push changes.
     - >
-      shippable_retry poetry install -E docs &&
       git config --global user.email "api-documentation@gro-intelligence.com" &&
       git config --global user.name "Gro Intelligence" &&
       git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&

--- a/shippable.yml
+++ b/shippable.yml
@@ -37,6 +37,8 @@ build:
     - >
       shippable_retry poetry install -E docs &&
       poetry run sphinx-build -W --keep-going docs docs/_build/html
+    # Check for broken links in the docs.
+    - poetry run sphinx-build -b linkcheck docs docs/_build/linkcheck
     # Build docs and push to gh-pages.
     # Note: git remote set-url is for setting a git url instead of an https
     # one, which is needed so Shippable can be authenticated to push changes.


### PR DESCRIPTION
- Adds check that latest docs build without warnings. Warnings can indicate formatting problems. Since docs are built automatically via CI, these warnings can accumulate silently over time (see #284).
- Adds check that external links are all valid.

Addresses #291 