### PR TITLE
Drop points with missing data when loading file to prevent nan propagation

### DIFF
--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -350,7 +350,7 @@ class SimilarRegion(object):
         # will return array of long-term averages for each time interval within a year, even for static
         result = np.zeros(self.t_int_per_year)
         try:
-            raw_data = pd.read_csv(full_path, parse_dates=[0,1], infer_datetime_format=True)
+            raw_data = pd.read_csv(full_path, parse_dates=[0,1], infer_datetime_format=True).dropna()
         except Exception as e:
             self._logger.error("Can not get data from file {}: {}".format(full_path, str(e)))
             return None, [] # empty list signals no data

--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -351,7 +351,7 @@ class SimilarRegion(object):
         result = np.zeros(self.t_int_per_year)
         try:
             raw_data = pd.read_csv(full_path, parse_dates=[0,1], infer_datetime_format=True)
-            num_rows_with_na = raw_data.isna().sum().max()
+            num_rows_with_na = (raw_data.isna().sum(axis=1)>0).sum() #raw_data.isna().sum().max()
             if num_rows_with_na > 0:
                 self._logger.warn("Note: dropping {} rows of {} that contain null values".format(num_rows_with_na,full_path))
                 raw_data.dropna(inplace=True)

--- a/api/client/samples/similar_regions/similar_region.py
+++ b/api/client/samples/similar_regions/similar_region.py
@@ -350,7 +350,11 @@ class SimilarRegion(object):
         # will return array of long-term averages for each time interval within a year, even for static
         result = np.zeros(self.t_int_per_year)
         try:
-            raw_data = pd.read_csv(full_path, parse_dates=[0,1], infer_datetime_format=True).dropna()
+            raw_data = pd.read_csv(full_path, parse_dates=[0,1], infer_datetime_format=True)
+            num_rows_with_na = raw_data.isna().sum().max()
+            if num_rows_with_na > 0:
+                self._logger.warn("Note: dropping {} rows of {} that contain null values".format(num_rows_with_na,full_path))
+                raw_data.dropna(inplace=True)
         except Exception as e:
             self._logger.error("Can not get data from file {}: {}".format(full_path, str(e)))
             return None, [] # empty list signals no data


### PR DESCRIPTION
A rather trivial change. If user data file has missing values they will be interpreted as nan's and propagated by numpy operations (specifically sum(axis=0) ) to the output. One nan is enough to ruin entire output. The easiest solution is just to drop such points immediately upon load which is done here.