### PR TITLE
fix: each GroClient has its own AsyncHTTPClient (CLEWS-32775)

### DIFF
--- a/groclient/batch_client_test.py
+++ b/groclient/batch_client_test.py
@@ -122,6 +122,18 @@ class BatchTests(TestCase):
 
         self.assertEqual(summation, 97680)
 
+    # Test that multiple GroClients each have their own AsyncHTTPClient. Note:
+    # this tests the fix for the `fetch called on closed AsyncHTTPClient`
+    # error. We can't test for that directly since the `fetch` call is mocked,
+    # so instead we just ensure that all GroClients have their own
+    # AsyncHTTPClient.
+    def test_batch_async_get_data_points_multiple_clients(self):
+        client = GroClient(MOCK_HOST, MOCK_TOKEN)
+        ahc_id1 = id(client._async_http_client)
+        client = GroClient(MOCK_HOST, MOCK_TOKEN)
+        ahc_id2 = id(client._async_http_client)
+        self.assertNotEqual(ahc_id1, ahc_id2)
+
     def test_batch_async_get_data_points_bad_request_error(self):
         responses = self.client.batch_async_get_data_points([mock_error_selection])
         self.assertTrue(isinstance(responses[0], BatchError))

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -65,11 +65,14 @@ class GroClient(object):
         self._data_series_queue = []  # added but not loaded in data frame
         self._data_frame = pandas.DataFrame()
         try:
-            self._async_http_client = AsyncHTTPClient()
+            # Each GroClient has its own IOLoop and AsyncHTTPClient.
             self._ioloop = IOLoop()
+            # Note: force_instance is needed to disable Tornado's
+            # pseudo-singleton AsyncHTTPClient caching behavior.
+            self._async_http_client = AsyncHTTPClient(force_instance=True)
         except Exception as e:
             self._logger.warning(
-                "Unable to initialize an event loop. Async methods disabled."
+                "Unable to initialize event loop, async methods disabled: {}".format(e)
             )
             self._async_http_client = None
             self._ioloop = None


### PR DESCRIPTION
This should finally, properly fix the `fetch() called on closed
AsyncHTTPClient` errors that we've been seeing since #257. The root
problem is that AsyncHTTPClient has an internal instance cache, so
creating a new GroClient when a previous one exists would reuse the
internal AsyncHTTPClient. If the previous GroClient falls out of scope,
the (shared) AsyncHTTPClient is closed (via GroClient.__del__),
resulting in errors when trying to use the new GroClient.

- See the Tornado docs for `AsyncHTTPClient`, `force_instance`, and the
  `close` method: https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient
- We explicitly started closing the AsyncHTTPClient in this PR (due to
  file descriptor leaking): https://github.com/gro-intelligence/api-client/pull/257
- This previous workaround fixed some instances of the error on Celery: https://github.com/gro-intelligence/api-client/pull/262
  It's still mysterious why that PR fixed things, and why more things on
  Celery weren't failing... Perhaps Celery does other things with
  IOLoops that result in this bug not being triggered sometimes.