### PR TITLE
fix at_time notebook links

### DIFF
--- a/api/client/samples/at-time-query-examples.ipynb
+++ b/api/client/samples/at-time-query-examples.ipynb
@@ -47,7 +47,8 @@
     "--------\n",
     "- https://developers.gro-intelligence.com/api.html#groclient.GroClient.get_data_points\n",
     "- https://developers.gro-intelligence.com/api.html#groclient.GroClient.lookup\n",
-    "- https://developers.gro-intelligence.com/faq.html#what-does-sourcelag-mean-when-i-use-client-lookup-to-inspect-a-source-s-details"
+    "- https://developers.gro-intelligence.com/faq.html#what-does-sourcelag-mean-when-i-use-client-lookup-to-inspect-a-source-s-details\n",
+    "- https://developers.gro-intelligence.com/querying-data.html#show-revisions"
    ]
   },
   {


### PR DESCRIPTION
Note: the "source lag" link was replaced with a link to the FAQ doc in our API developer docs, but there wasn't a corresponding question in that doc for the 2nd link: "how do I see previous values fo a time series point to see how the value changed over time".

If this functionality is still possible, we should probably add it to the current FAQ doc?