### PR TITLE
feat: make GroClient() args optional

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,12 @@ API Reference
   :local:
 
 =================
+Creating a client
+=================
+
+.. automethod:: groclient.GroClient.__init__
+
+=================
 Basic Exploration
 =================
 

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -72,7 +72,7 @@ def main():  # pragma: no cover
     parser.add_argument(
         "--print_token",
         action="store_true",
-        help="Ouput API access token for the given user email and password. "
+        help="Output API access token for the given user email and password. "
         "Save it in GROAPI_TOKEN environment variable.",
     )
     parser.add_argument(

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -83,11 +83,10 @@ class GroClient(object):
             >>> client = GroClient(access_token="your_token_here")
         """
         if access_token is None:
-            env_token = os.environ.get("GROAPI_TOKEN")
-            if env_token is None:
-                raise RuntimeError("$GROAPI_TOKEN environment variable must be set"
-                                   " when GroClient is constructed without access_token")
-            access_token = env_token
+            access_token = os.environ.get("GROAPI_TOKEN")
+            if access_token is None:
+                raise RuntimeError("$GROAPI_TOKEN environment variable must be set when "
+                                   "GroClient is constructed without the access_token argument")
         self.api_host = api_host
         self.access_token = access_token
         self._logger = lib.get_default_logger()

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 from functools import partial
 import itertools
-import time
 import json
+import os
+import time
 
 # Python3 support
 try:
@@ -57,7 +58,36 @@ class BatchError(APIError):
 class GroClient(object):
     """API client with stateful authentication for lib functions and extra convenience methods."""
 
-    def __init__(self, api_host, access_token):
+    def __init__(self, api_host=cfg.API_HOST, access_token=None):
+        """Construct a GroClient instance.
+
+        Parameters
+        ----------
+        api_host : string, optional
+            The API server hostname.
+        access_token : string, optional
+            Your Gro API authentication token. If not specified, the
+            :code:`$GROAPI_TOKEN` environment variable is used. See
+            :doc:`authentication`.
+
+        Raises
+        ------
+            RuntimeError
+                Raised when neither the :code:`access_token` parameter nor
+                :code:`$GROAPI_TOKEN` environment variable are set.
+
+        Examples
+        --------
+            >>> client = GroClient()  # token stored in $GROAPI_TOKEN
+
+            >>> client = GroClient(access_token="your_token_here")
+        """
+        if access_token is None:
+            env_token = os.environ.get("GROAPI_TOKEN")
+            if env_token is None:
+                raise RuntimeError("$GROAPI_TOKEN environment variable must be set"
+                                   " when GroClient is constructed without access_token")
+            access_token = env_token
         self.api_host = api_host
         self.access_token = access_token
         self._logger = lib.get_default_logger()


### PR DESCRIPTION
Changes `GroClient.__init__` so that both API host and access token are optional arguments. The API host defaults to the production API server and the access token defaults to `$GROAPI_TOKEN`. This saves clients (and us) from needing to spell out 'api.gro-intelligence.com' over and over.

Also added docstring for the constructor and added to developer docs: https://developers.gro-intelligence.com/jli-convenient-constructor/api.html#creating-a-client