### PR TITLE
CLEWS-36797: fix duplicated results in find_data_series() 

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -914,7 +914,7 @@ class GroClient(object):
         Parameters
         ----------
             show_revisions : boolean, optional
-                False by default, meaning only the latest value for each period. If true, will return 
+                False by default, meaning only the latest value for each period. If true, will return
                 all values for a given period, differentiated by the `reporting_date` field.
             show_available_date : boolean, optional
                 False by default. If true, will return the available date of each data point.
@@ -1307,6 +1307,8 @@ class GroClient(object):
                 data_series.pop("source_name", None)
                 # metadata is not hashable
                 data_series.pop("metadata", None)
+                # estimated data count is not hashable
+                data_series.pop("data_count_estimate", None)
                 series_hash = frozenset(data_series.items())
                 if series_hash not in ranking_groups:
                     ranking_groups.add(series_hash)


### PR DESCRIPTION
Minor fix for find_data_series()

@sahuguet  reported an issue when running
```
data_series = client.find_data_series(item="Corn", metric="gro yield", region="United States of America")
```

The original results contains some duplicates
```
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 25
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 32
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 2
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 14
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 63
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 19
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 106
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 25
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 32
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 2
```

This is due to the unnecessary key "data_count_estimate" used to check unique data series before making further available source/frequency call

Removing that should fix the problem. Now same request should return 
```
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 25
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 32
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 2
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 14
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 63
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 19
metricId: 170037, itemId: 274, regionId: 1215, partnerRegionId: 0, frequencyId: 9, sourceId: 106
metricId: 170037, itemId: 274, regionId: 15, partnerRegionId: 0, frequencyId: 9, sourceId: 19
metricId: 170037, itemId: 274, regionId: 1009, partnerRegionId: 0, frequencyId: 9, sourceId: 2
metricId: 170037, itemId: 274, regionId: 1132, partnerRegionId: 0, frequencyId: 9, sourceId: 14
```