### PR TITLE
add option to compress each series to a single column in get_df

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -937,7 +937,7 @@ class GroClient(object):
             self.access_token, self.api_host, entity_type, num_results, **selection
         )
 
-    def get_df(self, show_revisions=False, show_available_date=False, index_by_series=False, include_names=False):
+    def get_df(self, show_revisions=False, show_available_date=False, index_by_series=False, include_names=False, compress_format=False):
         """Call :meth:`~.get_data_points` for each saved data series and return as a combined
         dataframe.
 
@@ -957,6 +957,10 @@ class GroClient(object):
             include_names : boolean, optional
                If set, the dataframe will have additional columns with names of entities.
                Note that this will increase the size of the dataframe by about 5x.
+            compress_format: boolean, optional
+               If set, each series will be compressed to a single column in the dataframe, with the end_date column 
+               set as the dataframe inde. All the entity names for each series will be 
+               placed in column headers.
 
         Returns
         -------
@@ -975,13 +979,21 @@ class GroClient(object):
                 None, data_series, self.get_data_points(**data_series)
             )
 
+        if compress_format: include_names = True
         if include_names and not self._data_frame.empty:
             def get_name(entity_type_id, entity_id):
                 return self.lookup(ENTITY_KEY_TO_TYPE[entity_type_id], entity_id)['name']
 
+            name_cols = []
             for entity_type_id in DATA_SERIES_UNIQUE_TYPES_ID + ['unit_id']:
                 name_col = entity_type_id.replace('_id', '_name')
+                name_cols.append(name_col)
                 self._data_frame[name_col] = self._data_frame[entity_type_id].apply(partial(get_name, entity_type_id))
+
+            if compress_format:
+                table_df = self._data_frame.pivot_table(index='end_date', values='value',
+                                                    columns=name_cols)
+                return table_df
 
         if index_by_series and not self._data_frame.empty:
             idx_columns = intersect(DATA_SERIES_UNIQUE_TYPES_ID, self._data_frame.columns)

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -979,7 +979,9 @@ class GroClient(object):
                 None, data_series, self.get_data_points(**data_series)
             )
 
-        if compress_format: include_names = True
+        if compress_format: 
+            include_names = True
+        
         if include_names and not self._data_frame.empty:
             def get_name(entity_type_id, entity_id):
                 return self.lookup(ENTITY_KEY_TO_TYPE[entity_type_id], entity_id)['name']


### PR DESCRIPTION
it is helpful to provide users with a more streamlined dataframe output in some cases. This change compresses each series to a single column, indexed by end date