### PR TITLE
Switch from Shippable to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
             pip install -U pip wheel
             pip install poetry
             poetry install
-            echo $CIRCLE_TAG
 
       - run:
           name: "Run doctests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,15 +58,47 @@ jobs:
           name: "Check for broken links in the docs"
           command: |
             poetry run sphinx-build -b linkcheck docs docs/_build/linkcheck
-      
+
+      # Build docs and push to gh-pages.
+      # Note: git remote set-url is for setting a git url instead of an https
+      # one, which is needed so Shippable can be authenticated to push changes.
+      - run:
+          name: "Build docs and push to gh-pages"
+          command: >-
+            git config --global user.email "api-documentation@gro-intelligence.com" &&
+            git config --global user.name "Gro Intelligence" &&
+            git remote set-url origin git@github.com:$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git &&
+            poetry run bin/sphinx_push_ghpages.sh
+
       # Note: We need to install versioning library outside of the poetry venv.
-      # See note in CONTRIBUTING.md
-      # TODO: Build docs and push to gh-pages.
+      # See note in CONTRIBUTING.md.
       - run:
           name: "Build package"
           command: >-
             pip install poetry-dynamic-versioning &&
             poetry build
+
+      # Publish new development updates to TestPyPI whenever changes are merged
+      # to development.
+      # We only want to publish a new package when PRs are actually accepted and
+      # merged, which is why we check $CIRCLE_PULL_REQUEST.
+      - run:
+          name: "Push to testpypi"
+          command: >-
+            if [ "$CIRCLE_BRANCH" == "development" ] && [ -z $CIRCLE_PULL_REQUEST ]; then
+              poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
+              poetry publish -u __token__ -p $TESTPYPI_TOKEN -r testpypi
+            fi
+
+      # Publish new releases to PyPI.
+      # We only check whether this is a tagged build and if so, publish to pypi
+      # Check that $CIRCLE_TAG is not a null string
+      - run:
+          name: "Push to pypi"
+          command: >-
+            if [ -n $CIRCLE_TAG ]; then
+              poetry publish -u __token__ -p $PYPI_TOKEN
+            fi
 
     environment:
       GROAPI_TOKEN: dummytoken
@@ -75,4 +107,7 @@ workflows:
   ci-workflows:
     jobs:
       - ci
+        filters:
+          tags:
+            only: /^v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             pip install -U pip wheel
             pip install poetry
             poetry install
+            echo $CIRCLE_PULL_REQUEST
 
       - run:
           name: "Run doctests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
 workflows:
   ci-workflows:
     jobs:
-      - ci
-        filters:
-          tags:
-            only: /^v.*/
+      - ci:
+          filters:
+            tags:
+              only: /^v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             pip install -U pip wheel
             pip install poetry
             poetry install
-            echo $CIRCLE_PULL_REQUEST
+            echo $CIRCLE_TAG
 
       - run:
           name: "Run doctests"
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: "Push to testpypi"
           command: >-
-            if [ "$CIRCLE_BRANCH" == "development" ] && [ -z $CIRCLE_PULL_REQUEST ]; then
+            if [ "$CIRCLE_BRANCH" == "development" ] && [ -z "$CIRCLE_PULL_REQUEST" ]; then
               poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
               poetry publish -u __token__ -p $TESTPYPI_TOKEN -r testpypi
             fi
@@ -97,7 +97,7 @@ jobs:
       - run:
           name: "Push to pypi"
           command: >-
-            if [ -n $CIRCLE_TAG ]; then
+            if [ -n "$CIRCLE_TAG" ]; then
               poetry publish -u __token__ -p $PYPI_TOKEN
             fi
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -42,11 +42,11 @@ build:
     # Build docs and push to gh-pages.
     # Note: git remote set-url is for setting a git url instead of an https
     # one, which is needed so Shippable can be authenticated to push changes.
-    - >
-      git config --global user.email "api-documentation@gro-intelligence.com" &&
-      git config --global user.name "Gro Intelligence" &&
-      git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
-      poetry run bin/sphinx_push_ghpages.sh
+    # - >
+    #   git config --global user.email "api-documentation@gro-intelligence.com" &&
+    #   git config --global user.name "Gro Intelligence" &&
+    #   git remote set-url origin git@github.com:$REPO_FULL_NAME.git &&
+    #   poetry run bin/sphinx_push_ghpages.sh
     # Build package.
     # Note: We need to install versioning library outside of the poetry venv.
     # See note in CONTRIBUTING.md
@@ -61,15 +61,15 @@ build:
     # development branch. See: https://github.com/Shippable/support/issues/3938#issuecomment-342244497
     # We only want to publish a new package when PRs are actually accepted and
     # merged, which is why we check $IS_PULL_REQUEST.
-    - >
-      if [ "$BRANCH" == "development" -a "$IS_PULL_REQUEST" == "false" ]; then
-        poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
-        poetry publish -u __token__ -p $TESTPYPI_TOKEN -r testpypi
-      fi
+    # - >
+    #   if [ "$BRANCH" == "development" -a "$IS_PULL_REQUEST" == "false" ]; then
+    #     poetry config repositories.testpypi https://test.pypi.org/legacy/ &&
+    #     poetry publish -u __token__ -p $TESTPYPI_TOKEN -r testpypi
+    #   fi
     # Publish new releases to PyPI.
     # Note: requires configuring Shippable for release webhooks:
     # http://docs.shippable.com/ci/trigger-job/#configuring-build-triggers
-    - >
-      if [ "$IS_RELEASE" == "true" ]; then
-        poetry publish -u __token__ -p $PYPI_TOKEN
-      fi
+    # - >
+    #   if [ "$IS_RELEASE" == "true" ]; then
+    #     poetry publish -u __token__ -p $PYPI_TOKEN
+    #   fi


### PR DESCRIPTION
This transfers the following functionality from Shippable to CircleCI:

- Updating the developer documentation
- Publishing to testpypi
- Publishing to pypi