### PR TITLE
CLEWS-36799: support unit conversion in batch_async_get_data_points()

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -320,6 +320,15 @@ class GroClient(object):
             points = lib.list_of_series_to_single_series(
                 list_of_series_points, False, include_historical, include_available_date
             )
+            # Apply unit conversion if a unit is specified
+            if "unit_id" in selection:
+                raise gen.Return(list(
+                    map(
+                        partial(self.convert_unit, target_unit_id=selection["unit_id"]),
+                        points,
+                    )
+                ))
+
             raise gen.Return(points)
         except BatchError as b:
             raise gen.Return(b)


### PR DESCRIPTION
Fix a bug with `batch_async_get_data_points()` 

`get_data_points_generator()` misses the same unit conversion as `get_data_points()` does

Note:
this is a quick fix for immediate need, we still have a long-term todo to deprecate `get_data_points_generator` 

Tested

```
series_list = [{
        'metric_id': 170037,
        'item_id': 274,
        'region_id': 1215,
        'partner_region_id': 0,
        'source_id': 32, 'frequency_id': 9,
        'unit_id': 61,
        'start_date': '2020-01-01T00:00:00.000Z'
    }]
    output = client.batch_async_get_data_points(series_list, output_list=[], map_result=map_response)
```
on development branch, returns 
```
{'start_date': '2020-01-01T00:00:00.000Z', 'end_date': '2020-12-31T00:00:00.000Z', 'value': 180.642272658549, 'unit_id': 284, 'metadata': {}, 'input_unit_id': 284, 'input_unit_scale': 1, 'reporting_date': None, 'metric_id': 170037, 'item_id': 274, 'region_id': 1215, 'partner_region_id': 0, 'frequency_id': 9}
{'start_date': '2021-01-01T00:00:00.000Z', 'end_date': '2021-12-31T00:00:00.000Z', 'value': 170.33190349423, 'unit_id': 284, 'metadata': {}, 'input_unit_id': 284, 'input_unit_scale': 1, 'reporting_date': None, 'metric_id': 170037, 'item_id': 274, 'region_id': 1215, 'partner_region_id': 0, 'frequency_id': 9}
```

on this branch, it returns

```
{'start_date': '2020-01-01T00:00:00.000Z', 'end_date': '2020-12-31T00:00:00.000Z', 'value': 11.338540400413159, 'unit_id': 61, 'metadata': {}, 'input_unit_id': 284, 'input_unit_scale': 1, 'reporting_date': None, 'metric_id': 170037, 'item_id': 274, 'region_id': 1215, 'partner_region_id': 0, 'frequency_id': 9}
{'start_date': '2021-01-01T00:00:00.000Z', 'end_date': '2021-12-31T00:00:00.000Z', 'value': 10.691379934635702, 'unit_id': 61, 'metadata': {}, 'input_unit_id': 284, 'input_unit_scale': 1, 'reporting_date': None, 'metric_id': 170037, 'item_id': 274, 'region_id': 1215, 'partner_region_id': 0, 'frequency_id': 9}
```

