### PR TITLE
CLEWS-39481 Introduce get_ancestors function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,8 @@ Basic Exploration
 
 .. automethod:: groclient.GroClient.search_for_entity
 
+.. automethod:: groclient.GroClient.get_ancestors
+
 .. automethod:: groclient.GroClient.get_descendant
 
 .. automethod:: groclient.GroClient.get_data_series

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,7 +22,7 @@ Basic Exploration
 
 .. automethod:: groclient.GroClient.search_for_entity
 
-.. automethod:: groclient.GroClient.get_ancestors
+.. automethod:: groclient.GroClient.get_ancestor
 
 .. automethod:: groclient.GroClient.get_descendant
 

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -745,6 +745,56 @@ class GroClient(object):
         """
         return lib.get_geojson(self.access_token, self.api_host, region_id, zoom_level)
 
+    def get_ancestors(
+        self,
+        entity_type,
+        entity_id,
+        distance=None,
+        include_details=True,
+    ):
+        """Given an item, metric or region, returns all its ancestors i.e.
+        entities that "contain" in the given entity
+
+        Parameters
+        ----------
+        entity_type : { 'metrics', 'items', 'regions' }
+        entity_id : integer
+        distance: integer, optional
+            Return all entities that contain the entity_id at maximum distance.
+            If not provided, get all ancestors.
+        include_details : boolean, optional
+            True by default. Will perform a lookup() on each ancestor to find name,
+            definition, etc. If this option is set to False, only ids of ancestor
+            entities will be returned, which makes execution significantly faster.
+
+        Returns
+        -------
+        list of dicts
+
+            Example::
+
+                [{
+                    'id': 134,
+                    'name': 'Cattle hides, wet-salted',
+                    'definition': 'Hides and skins of domesticated cattle-animals ...',
+                } , {
+                    'id': 382,
+                    'name': 'Calf skins, wet-salted',
+                    'definition': 'Wet-salted hides and skins of calves-animals of ...'
+                }, ...]
+
+            See output of :meth:`~.lookup`
+
+        """
+        return lib.get_ancestors(
+            self.access_token,
+            self.api_host,
+            entity_type,
+            entity_id,
+            distance,
+            include_details,
+        )
+
     def get_descendant(
         self,
         entity_type,
@@ -798,7 +848,6 @@ class GroClient(object):
             distance,
             include_details,
         )
-
 
     def get_descendant_regions(
         self,

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -745,7 +745,7 @@ class GroClient(object):
         """
         return lib.get_geojson(self.access_token, self.api_host, region_id, zoom_level)
 
-    def get_ancestors(
+    def get_ancestor(
         self,
         entity_type,
         entity_id,
@@ -786,7 +786,7 @@ class GroClient(object):
             See output of :meth:`~.lookup`
 
         """
-        return lib.get_ancestors(
+        return lib.get_ancestor(
             self.access_token,
             self.api_host,
             entity_type,

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -110,7 +110,7 @@ def mock_get_descendant(
         return [{"id": child["id"]} for child in childs]
 
 
-def mock_get_ancestors(
+def mock_get_ancestor(
     access_token,
     api_host,
     entity_type,
@@ -236,7 +236,7 @@ def mock_get_data_points(access_token, api_host, **selections):
 @patch("groclient.lib.get_geo_centre", MagicMock(side_effect=mock_get_geo_centre))
 @patch("groclient.lib.get_geojsons", MagicMock(side_effect=mock_get_geojsons))
 @patch("groclient.lib.get_geojson", MagicMock(side_effect=mock_get_geojson))
-@patch("groclient.lib.get_ancestors", MagicMock(side_effect=mock_get_ancestors))
+@patch("groclient.lib.get_ancestor", MagicMock(side_effect=mock_get_ancestor))
 @patch("groclient.lib.get_descendant", MagicMock(side_effect=mock_get_descendant))
 @patch(
     "groclient.lib.get_descendant_regions",
@@ -324,11 +324,11 @@ class GroClientTests(TestCase):
         self.assertTrue("coordinates" in geojson["geometries"][0])
         self.assertTrue(geojson["geometries"][0]['coordinates'][0][0][0] == [-38, -4])
 
-    def test_get_ancestors(self):
+    def test_get_ancestor(self):
         self.assertTrue("name" in self.client.get_descendant('metrics', 119)[0])
         self.assertTrue(
             "name"
-            not in self.client.get_ancestors('regions', 12345, include_details=False)[0]
+            not in self.client.get_ancestor('regions', 12345, include_details=False)[0]
         )
 
     def test_get_descendant(self):

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -110,6 +110,26 @@ def mock_get_descendant(
         return [{"id": child["id"]} for child in childs]
 
 
+def mock_get_ancestors(
+    access_token,
+    api_host,
+    entity_type,
+    entity_id,
+    distance,
+    include_details,
+):
+
+    childs = [
+            child
+            for child in mock_entities[entity_type].values()
+            if 12345 in child["contains"]
+        ]
+    if include_details:
+        return childs
+    else:
+        return [{"id": child["id"]} for child in childs]
+
+
 def mock_get_descendant_regions(
     access_token,
     api_host,
@@ -216,6 +236,7 @@ def mock_get_data_points(access_token, api_host, **selections):
 @patch("groclient.lib.get_geo_centre", MagicMock(side_effect=mock_get_geo_centre))
 @patch("groclient.lib.get_geojsons", MagicMock(side_effect=mock_get_geojsons))
 @patch("groclient.lib.get_geojson", MagicMock(side_effect=mock_get_geojson))
+@patch("groclient.lib.get_ancestors", MagicMock(side_effect=mock_get_ancestors))
 @patch("groclient.lib.get_descendant", MagicMock(side_effect=mock_get_descendant))
 @patch(
     "groclient.lib.get_descendant_regions",
@@ -302,6 +323,13 @@ class GroClientTests(TestCase):
         self.assertTrue("type" in geojson["geometries"][0])
         self.assertTrue("coordinates" in geojson["geometries"][0])
         self.assertTrue(geojson["geometries"][0]['coordinates'][0][0][0] == [-38, -4])
+
+    def test_get_ancestors(self):
+        self.assertTrue("name" in self.client.get_descendant('metrics', 119)[0])
+        self.assertTrue(
+            "name"
+            not in self.client.get_ancestors('regions', 12345, include_details=False)[0]
+        )
 
     def test_get_descendant(self):
         self.assertTrue("name" in self.client.get_descendant('metrics', 119)[0])

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -604,7 +604,7 @@ def get_geojson(access_token, api_host, region_id, zoom_level):
         return json.loads(region['geojson'])
 
 
-def get_ancestors(access_token, api_host, entity_type, entity_id, distance=None,
+def get_ancestor(access_token, api_host, entity_type, entity_id, distance=None,
                    include_details=True):
     url = '/'.join(['https:', '', api_host, 'v2/{}/belongs-to'.format(entity_type)])
     headers = {'authorization': 'Bearer ' + access_token}

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -604,6 +604,26 @@ def get_geojson(access_token, api_host, region_id, zoom_level):
         return json.loads(region['geojson'])
 
 
+def get_ancestors(access_token, api_host, entity_type, entity_id, distance=None,
+                   include_details=True):
+    url = '/'.join(['https:', '', api_host, 'v2/{}/belongs-to'.format(entity_type)])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = {'ids': [entity_id]}
+    if distance:
+        params['distance'] = distance
+    else:
+        params['distance'] = -1
+
+    resp = get_data(url, headers, params)
+    ancestor_entity_ids = resp.json()['data'][str(entity_id)]
+
+    if include_details:
+        entity_details = lookup(access_token, api_host, entity_type, ancestor_entity_ids)
+        return [entity_details[str(child_entity_id)] for child_entity_id in ancestor_entity_ids]
+
+    return [{'id': ancestor_entity_id} for ancestor_entity_id in ancestor_entity_ids]
+
+
 def get_descendant(access_token, api_host, entity_type, entity_id, distance=None,
                    include_details=True):
     url = '/'.join(['https:', '', api_host, 'v2/{}/contains'.format(entity_type)])

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -446,7 +446,7 @@ def lookup_mock(MOCK_TOKEN, MOCK_HOST, entity_type, entity_ids):
 
 @mock.patch('groclient.lib.lookup')
 @mock.patch('requests.get')
-def test_get_ancestors(mock_requests_get, lookup_mocked):
+def test_get_ancestor(mock_requests_get, lookup_mocked):
     mock_requests_get.return_value.json.return_value = {'data': {'1': [3, 4]}}
     mock_requests_get.return_value.status_code = 200
     lookup_mocked.side_effect = lookup_mock

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -446,6 +446,33 @@ def lookup_mock(MOCK_TOKEN, MOCK_HOST, entity_type, entity_ids):
 
 @mock.patch('groclient.lib.lookup')
 @mock.patch('requests.get')
+def test_get_ancestors(mock_requests_get, lookup_mocked):
+    mock_requests_get.return_value.json.return_value = {'data': {'1': [3, 4]}}
+    mock_requests_get.return_value.status_code = 200
+    lookup_mocked.side_effect = lookup_mock
+
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 1) == [
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'},
+        {'id': 4, 'name': 'ancestor', 'contains': [3], 'belongsTo': [], 'definition': 'def4'}
+    ]
+    
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'metrics', 1, include_details=True) == [
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'},
+        {'id': 4, 'name': 'ancestor', 'contains': [3], 'belongsTo': [], 'definition': 'def4'}
+    ]
+
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 1, include_details=False) == [
+        {'id': 3}, {'id': 4}
+    ]
+
+    mock_requests_get.return_value.json.return_value = {'data': {'2': [3]}}
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'items', 2, distance=1) == [
+        {'id': 3, 'name': 'parent', 'contains': [1, 2], 'belongsTo': [4], 'definition': 'def3'}
+    ]
+
+
+@mock.patch('groclient.lib.lookup')
+@mock.patch('requests.get')
 def test_get_descendant(mock_requests_get, lookup_mocked):
     mock_requests_get.return_value.json.return_value = {'data': {'4': [1, 2, 3]}}
     mock_requests_get.return_value.status_code = 200


### PR DESCRIPTION
Similar to `get_descendants`, introduce `get_ancestors` method that returns all ancestors for a given entity id.  

Usage

```
>>> from groclient import GroClient
>>> client = GroClient(API_HOST, ACCESS_TOKEN)

>>> client.get_ancestors('regions', 1107, 1, False)
[{'id': 0}, {'id': 11}, {'id': 100000004}, {'id': 100000008}, {'id': 100000009}, {'id': 100000010}, {'id': 100000012}, {'id': 100017849}]

>>> client.get_ancestors('regions', 13455, None, False)
[{'id': 0}, {'id': 11}, {'id': 1107}, {'id': 100000004}, {'id': 100000008}, {'id': 100000009}, {'id': 100000010}, {'id': 100000012}, {'id': 100000195}, {'id': 100017849}]