### PR TITLE
Document new param :available_since in API client

### DIFF
--- a/docs/querying-data.rst
+++ b/docs/querying-data.rst
@@ -33,7 +33,7 @@ Get data points
       'frequency_id': 9
   })
 
-The above query has completed fields for :code:`metric_id`, :code:`item_id`, :code:`region_id`, :code:`source_id`, and :code:`frequency_id`. However, :meth:`groclient.GroClient.get_data_points` can also accept fields to further narrow your data series of interest: :code:`partner_region_id` (used only in series that represent a flow between two places), :code:`start_date`, :code:`end_date`, :code:`show_revions`, :code:`insert_null`, and :code:`at_time`.
+The above query has completed fields for :code:`metric_id`, :code:`item_id`, :code:`region_id`, :code:`source_id`, and :code:`frequency_id`. However, :meth:`groclient.GroClient.get_data_points` can also accept fields to further narrow your data series of interest: :code:`partner_region_id` (used only in series that represent a flow between two places), :code:`start_date`, :code:`end_date`, :code:`show_revions`, :code:`insert_null`, :code:`at_time`, and :code:`available_since`.
 
 Making your query more specific will speed up your query by limiting the amount of data requested.
 

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1244,6 +1244,8 @@ class GroClient(object):
             :sample:`at-time-query-examples.ipynb` for more details.
         include_historical : boolean, optional
             True by default, will include historical regions that are part of your selections
+        available_since : string, optional
+            Fetch points since last data retrieval where available date is equal to or after this date
 
         Returns
         -------

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -351,7 +351,8 @@ def get_data_call_params(**selection):
     show_available_date : boolean, optional
     insert_null : boolean, optional
     show_metadata : boolean, optional
-    at_time : string, optional
+    at_time : string, optional,
+    available_since : string, optional
 
     Returns
     -------
@@ -363,7 +364,7 @@ def get_data_call_params(**selection):
     for key, value in list(selection.items()):
         if key == 'show_metadata':
             params[groclient.utils.str_snake_to_camel('show_meta_data')] = value
-        if key in ('start_date', 'end_date', 'show_revisions', 'show_available_date', 'insert_null', 'at_time'):
+        if key in ('start_date', 'end_date', 'show_revisions', 'show_available_date', 'insert_null', 'at_time', 'available_since'):
             params[groclient.utils.str_snake_to_camel(key)] = value
     params['responseType'] = 'list_of_series'
     return params


### PR DESCRIPTION
Document newly supported param `available_since` by adding it as inline comments and updating querying-data docs