### PR TITLE
DELI-276 include historical refactor for get_descendant()

### DIFF
--- a/api/client/samples/drought/el_nino_la_nina_and_droughts_in_east_africa.ipynb
+++ b/api/client/samples/drought/el_nino_la_nina_and_droughts_in_east_africa.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "## Drought\n",
     "\n",
-    "There are many data series related to drought. Here we use the [Gro Drought Index (GDI)](https://gro-intelligence.com/gro-models/gro-drought-index), which is available at the district and province level, daily and weekly.  For simplicity, let us take the weekly GDI series at the province level."
+    "There are many data series related to drought. Here we use the [Gro Drought Index (GDI)](https://gro-intelligence.com/models/gro-drought-index), which is available at the district and province level, daily and weekly.  For simplicity, let us take the weekly GDI series at the province level."
    ]
   },
   {

--- a/docs/modeling-resources.rst
+++ b/docs/modeling-resources.rst
@@ -8,7 +8,7 @@ Modeling Resources
 Gro Crop Cover
 ==============
 
-Gro's proprietary high-resolution crop covers are currently used in the `Gro yield models <https://gro-intelligence.com/gro-models>`_. These have proven very successful i.e. more accurate for yield modeling than the best available alternatives. Gro does not plan on developing a yield model for every crop or region in the world, so our models will always be limited to the regions and crops where we can help push the envelope. Users can access our crop covers in the `Gro web app <https://app.gro-intelligence.com/displays/jdOQrvERw>`_ and the API, or from the download links below. In the web app and API, users can interact with detailed cropland covers that indicate the intensity of crop cover for a particular pixel. Below users can download .tif files of low and high-confidence crop covers which represent, as a binary value, whether a crop is growing in a specific pixel.
+Gro's proprietary high-resolution crop covers are currently used in the `Gro yield models <https://gro-intelligence.com/platform/models-and-applications>`_. These have proven very successful i.e. more accurate for yield modeling than the best available alternatives. Gro does not plan on developing a yield model for every crop or region in the world, so our models will always be limited to the regions and crops where we can help push the envelope. Users can access our crop covers in the `Gro web app <https://app.gro-intelligence.com/displays/jdOQrvERw>`_ and the API, or from the download links below. In the web app and API, users can interact with detailed cropland covers that indicate the intensity of crop cover for a particular pixel. Below users can download .tif files of low and high-confidence crop covers which represent, as a binary value, whether a crop is growing in a specific pixel.
 
 Methodology
 -----------
@@ -148,7 +148,7 @@ A low-confidence cover and a high-confidence cover were made from the yearly cro
 Gro Yield Model Backtest Data
 =============================
 
-`Gro yield models <https://gro-intelligence.com/gro-models>`_ provide live forecasts for crops in different regions around the world. To supplement our in-depth papers on the models, we provide backtesting data for model evaluation and comparisons.
+`Gro yield models <https://gro-intelligence.com/platform/models-and-applications>`_ provide live forecasts for crops in different regions around the world. To supplement our in-depth papers on the models, we provide backtesting data for model evaluation and comparisons.
 
 File Formats
 ------------

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -885,7 +885,7 @@ class GroClient(object):
         descendant_level : integer, optional
             The region level of interest. See REGION_LEVELS constant. This should only be specified
             if the `entity_type` is 'regions'. If provided along with `distance`, `distance` will
-            take precedence. If not provided, and `distance` not provided, get all ancestors.
+            take precedence. If not provided, and `distance` not provided, get all descendants.
         include_historical : boolean, optional
             True by default. If False is specified, regions that only exist in historical data
             (e.g. the Soviet Union) will be excluded.

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -676,7 +676,6 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
             params['distance'] = -1
 
     params['includeHistorical'] = include_historical
-
     resp = get_data(url, headers, params)
     descendant_entity_ids = resp.json()['data'][str(entity_id)]
 

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -676,6 +676,7 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
             params['distance'] = -1
 
     params['includeHistorical'] = include_historical
+
     resp = get_data(url, headers, params)
     descendant_entity_ids = resp.json()['data'][str(entity_id)]
 

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -675,20 +675,16 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
         else:
             params['distance'] = -1
 
+    if not include_historical:
+        params['includeHistorical'] = 'false'
+
     resp = get_data(url, headers, params)
     descendant_entity_ids = resp.json()['data'][str(entity_id)]
 
     # Filter out regions with the 'historical' flag set to true
-    if not include_historical or include_details:
+    if include_details:
         entity_details = lookup(access_token, api_host, entity_type, descendant_entity_ids)
-
-        if not include_historical:
-            descendant_entity_ids = [entity['id'] for entity in entity_details.values()
-                                     if not entity['historical']]
-
-        if include_details:
-            return [entity_details[str(child_entity_id)] for child_entity_id in
-                    descendant_entity_ids]
+        return [entity_details[str(child_entity_id)] for child_entity_id in descendant_entity_ids]
 
     return [{'id': descendant_entity_id} for descendant_entity_id in descendant_entity_ids]
 

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -675,8 +675,7 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
         else:
             params['distance'] = -1
 
-    if not include_historical:
-        params['includeHistorical'] = 'false'
+    params['includeHistorical'] = include_historical
 
     resp = get_data(url, headers, params)
     descendant_entity_ids = resp.json()['data'][str(entity_id)]

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -454,18 +454,20 @@ def test_get_descendant(mock_requests_get, lookup_mocked):
         {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
     ]
 
-    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False) == [
-        {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
-    ]
-
     assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3,
                               include_historical=True, include_details=True) == [
         {'id': 1, 'name': 'region 1', 'contains': [], 'belongsTo': [3], 'historical': True},
         {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
     ]
 
+    mock_requests_get.return_value.json.return_value = {'data': {'3': [2]}}
     assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False,
                               include_details=False) == [{'id': 2}]
+
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False,
+                              include_details=True) == [
+        {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
+    ]
 
 
 @mock.patch('requests.get')


### PR DESCRIPTION
Previously get_descendant() made a call to `v2/regions/contains` to get the descendant ids for a given region, then if include_historical was set to false, it would do batch lookups of the descendant ids against the `v2/regions` endpoint. After getting a response, it would filter the data for the regions that had include_historical set to false.

This PR is directly related to the DELI-276 PR on the `gro/api` code base, where the includeHistorical parameter was added to the `/v2/reginos/contains` endpoint as an optional parameter. Thus, now the filtering for the historical regions is done at the DB level, and unnecessary processing at the python API client is no longer necessary.