### PR TITLE
copied changes from DELI-276-include-historical-refactor

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -885,7 +885,7 @@ class GroClient(object):
         descendant_level : integer, optional
             The region level of interest. See REGION_LEVELS constant. This should only be specified
             if the `entity_type` is 'regions'. If provided along with `distance`, `distance` will
-            take precedence. If not provided, and `distance` not provided, get all ancestors.
+            take precedence. If not provided, and `distance` not provided, get all descendants.
         include_historical : boolean, optional
             True by default. If False is specified, regions that only exist in historical data
             (e.g. the Soviet Union) will be excluded.

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -675,20 +675,15 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
         else:
             params['distance'] = -1
 
+    params['includeHistorical'] = include_historical
+
     resp = get_data(url, headers, params)
     descendant_entity_ids = resp.json()['data'][str(entity_id)]
 
     # Filter out regions with the 'historical' flag set to true
-    if not include_historical or include_details:
+    if include_details:
         entity_details = lookup(access_token, api_host, entity_type, descendant_entity_ids)
-
-        if not include_historical:
-            descendant_entity_ids = [entity['id'] for entity in entity_details.values()
-                                     if not entity['historical']]
-
-        if include_details:
-            return [entity_details[str(child_entity_id)] for child_entity_id in
-                    descendant_entity_ids]
+        return [entity_details[str(child_entity_id)] for child_entity_id in descendant_entity_ids]
 
     return [{'id': descendant_entity_id} for descendant_entity_id in descendant_entity_ids]
 

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -454,18 +454,20 @@ def test_get_descendant(mock_requests_get, lookup_mocked):
         {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
     ]
 
-    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False) == [
-        {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
-    ]
-
     assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3,
                               include_historical=True, include_details=True) == [
         {'id': 1, 'name': 'region 1', 'contains': [], 'belongsTo': [3], 'historical': True},
         {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
     ]
 
+    mock_requests_get.return_value.json.return_value = {'data': {'3': [2]}}
     assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False,
                               include_details=False) == [{'id': 2}]
+
+    assert lib.get_descendant(MOCK_TOKEN, MOCK_HOST, 'regions', 3, include_historical=False,
+                              include_details=True) == [
+        {'id': 2, 'name': 'region 2', 'contains': [], 'belongsTo': [3], 'historical': False}
+    ]
 
 
 @mock.patch('requests.get')


### PR DESCRIPTION
Previously get_descendant() made a call to v2/regions/contains to get the descendant ids for a given region, then if include_historical was set to false, it would do batch lookups of the descendant ids against the v2/regions endpoint. After getting a response, it would filter the data for the regions that had include_historical set to false.

This PR is directly related to the DELI-276 PR on the gro/api code base, where the includeHistorical parameter was added to the /v2/regions/contains endpoint as an optional parameter. Thus, now the filtering for the historical regions is done at the DB level, and unnecessary processing at the python API client is no longer necessary.