### PR TITLE
GAIA-9995 Expose API endpoints related to area weighting service in Gro Client lib

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1711,6 +1711,43 @@ class GroClient(object):
         point["unit_id"] = target_unit_id
         return point
 
+
+    def get_area_weighting_series_names(self):
+        """ Returns a list of valid series names that can be used to 
+            form the inputs of :meth:`~.get_area_weighted_series`.
+
+        Returns
+        -------
+        list of strings
+
+            Example::
+                [   "CPC_max_temp_daily",
+                    "CPC_min_temp_daily",
+                    "ET_PET_monthly",
+                    "GDI_daily",
+                    ...
+                ]
+        """
+        return lib.get_area_weighting_series_names(self.access_token, self.api_host)
+
+
+    def get_area_weighting_weight_names(self):
+        """ Returns a list of valid weight names that can be used to 
+            form the inputs of :meth:`~.get_area_weighted_series`.
+
+        Returns
+        -------
+        list of strings
+
+            Example::
+                [   "2008 RMA Corn Area Indemnified (Acres)",
+                    "2008 RMA Corn Drought Indemnity Paid to Producer (USD)",
+                    ...
+                ]
+        """
+        return lib.get_area_weighting_weight_names(self.access_token, self.api_host)
+
+
     def get_area_weighted_series(self, series_name, weight_names, region_id,
                                  method='sum', latest_date_only=False):
         """Compute weighted average on selected series with the given weights.

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1710,3 +1710,36 @@ class GroClient(object):
             point["metadata"]["conf_interval"] = lib.convert_value(point["metadata"]["conf_interval"], from_convert_factor, to_convert_factor)
         point["unit_id"] = target_unit_id
         return point
+
+    def get_area_weighted_series(self, series_name, weight_names, region_id,
+                                 method='sum', latest_date_only=False):
+        """Compute weighted average on selected series with the given weights.
+
+        Returns a dictionary mapping dates to weighted values.
+
+        Parameters
+        ----------
+        series_name: str
+            Should be a tag identifying the desired Gro data series. e.g. 'NDVI_8day'
+            For getting the full list of valid series names, please call :meth:`~.get_area_weighting_series_names`
+        weight_names: list of strs
+            List of weight names that will be used to weight the provided series. e.g. ['Barley (ha)', 'Corn (ha)']
+            For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
+        region_id: integer
+            The region for which the weighted series will be computed
+        method: str, optional
+            'sum' by default. Multi-crop weights can be calculated with either 'sum' or 'normalize' method.
+        latest_date_only: bool, optional
+            False by default. If True, will return a single key-value pair where the key is the latested date.
+            e.g. {'2000-03-12': 0.221}
+
+        Returns
+        -------
+        dict
+
+            Example::
+                {'2000-02-25': 0.217, '2000-03-04': 0.217, '2000-03-12': 0.221, ...}
+        """
+        return lib.get_area_weighted_series(
+            self.access_token, self.api_host, series_name, weight_names, region_id, method, latest_date_only
+        )

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -231,6 +231,19 @@ def mock_get_data_points(access_token, api_host, **selections):
         return data_points
 
 
+def mock_get_area_weighting_series_names(access_token, api_host):
+    return ["CPC_max_temp_daily", "CPC_min_temp_daily", "ET_PET_monthly"]
+
+
+def mock_get_area_weighting_weight_names(access_token, api_host):
+    return ["Almonds (CA only)", "Bananas (ha)", "Canola (ha)"]
+
+
+def mock_get_area_weighted_series(access_token, api_host, series_name, weight_names,
+                                  region_id, method, latest_date_only):
+    return {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
+
+
 @patch("groclient.lib.get_available", MagicMock(side_effect=mock_get_available))
 @patch("groclient.lib.list_available", MagicMock(side_effect=mock_list_available))
 @patch("groclient.lib.lookup", MagicMock(side_effect=mock_lookup))
@@ -254,6 +267,9 @@ def mock_get_data_points(access_token, api_host, **selections):
 )
 @patch("groclient.lib.get_top", MagicMock(side_effect=mock_get_top))
 @patch("groclient.lib.get_data_points", MagicMock(side_effect=mock_get_data_points))
+@patch("groclient.lib.get_area_weighting_series_names", MagicMock(side_effect=mock_get_area_weighting_series_names))
+@patch("groclient.lib.get_area_weighting_weight_names", MagicMock(side_effect=mock_get_area_weighting_weight_names))
+@patch("groclient.lib.get_area_weighted_series", MagicMock(side_effect=mock_get_area_weighted_series))
 class GroClientTests(TestCase):
     def setUp(self):
         self.client = GroClient(MOCK_HOST, MOCK_TOKEN)
@@ -536,6 +552,24 @@ class GroClientTests(TestCase):
 
         with self.assertRaises(Exception):
             self.client.convert_unit({"value": None, "unit_id": 10}, 43)
+
+    def test_get_area_weighting_series_names(self):
+        self.assertEqual(
+            self.client.get_area_weighting_series_names(),
+            ["CPC_max_temp_daily", "CPC_min_temp_daily", "ET_PET_monthly"]
+        )
+
+    def test_get_area_weighting_weight_names(self):
+        self.assertEqual(
+            self.client.get_area_weighting_weight_names(),
+            ["Almonds (CA only)", "Bananas (ha)", "Canola (ha)"]
+        )
+
+    def test_get_area_weighted_series(self):
+        self.assertEqual(
+            self.client.get_area_weighted_series('NDVI_8day', ['Barley (ha)', 'Corn (ha)'], 1215),
+            {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
+        )
 
 class GroClientConstructorTests(TestCase):
     PROD_API_HOST = "api.gro-intelligence.com"

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -688,6 +688,22 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
     return [{'id': descendant_entity_id} for descendant_entity_id in descendant_entity_ids]
 
 
+def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id,
+                             method, latest_date_only):
+    url = '/'.join(['https:', '', api_host, 'area-weighting'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    params = {
+        'seriesName': series_name,
+        'weightNames': weight_names,
+        'regionId': region_id,
+        'method': method,
+        'latestDateOnly': latest_date_only
+    }
+    print('===url', url, params);#####
+    resp = get_data(url, headers, params=params)
+    return resp.json()
+
+
 if __name__ == '__main__':
     # To run doctests:
     # $ python lib.py -v

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -688,6 +688,20 @@ def get_descendant(access_token, api_host, entity_type, entity_id, distance=None
     return [{'id': descendant_entity_id} for descendant_entity_id in descendant_entity_ids]
 
 
+def get_area_weighting_series_names(access_token, api_host):
+    url = '/'.join(['https:', '', api_host, 'area-weighting-series-names'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers)
+    return resp.json()
+
+
+def get_area_weighting_weight_names(access_token, api_host):
+    url = '/'.join(['https:', '', api_host, 'area-weighting-weight-names'])
+    headers = {'authorization': 'Bearer ' + access_token}
+    resp = get_data(url, headers)
+    return resp.json()
+
+
 def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id,
                              method, latest_date_only):
     url = '/'.join(['https:', '', api_host, 'area-weighting'])
@@ -699,7 +713,6 @@ def get_area_weighted_series(access_token, api_host, series_name, weight_names, 
         'method': method,
         'latestDateOnly': latest_date_only
     }
-    print('===url', url, params);#####
     resp = get_data(url, headers, params=params)
     return resp.json()
 

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -572,3 +572,23 @@ def test_get_geo_json(geojsons_mocked):
         'geometries': [{'type': 'MultiPolygon', 'coordinates': [[[[-155.651382446, 20.1647224430001]]]]}]
     }
     assert lib.get_geojson(MOCK_TOKEN, MOCK_HOST, 1215, 7) == expected_return
+
+@mock.patch('requests.get')
+def test_get_area_weighting_series_names(mock_requests_get):
+    api_response = ["CPC_max_temp_daily", "CPC_min_temp_daily", "ET_PET_monthly"]
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
+    assert lib.get_area_weighting_series_names(MOCK_TOKEN, MOCK_HOST) == ["CPC_max_temp_daily", "CPC_min_temp_daily", "ET_PET_monthly"]
+
+@mock.patch('requests.get')
+def test_get_area_weighting_weight_names(mock_requests_get):
+    api_response = ["Almonds (CA only)", "Bananas (ha)", "Canola (ha)"]
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
+    assert lib.get_area_weighting_weight_names(MOCK_TOKEN, MOCK_HOST) == ["Almonds (CA only)", "Bananas (ha)", "Canola (ha)"]
+
+@mock.patch('requests.get')
+def test_get_area_weighted_series(mock_requests_get):
+    api_response = {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
+
+    expected_return = {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
+    assert lib.get_area_weighted_series(MOCK_TOKEN, MOCK_HOST, 'NDVI_8day', ['Barley (ha)', 'Corn (ha)'], 1215, 'sum', False) == expected_return


### PR DESCRIPTION
Going to expose the following endpoints in Gro Client lib:
- GET /area-weighting
- GET /area-weighting-series-names
- GET /area-weighting-weight-names

status: ready for review

for testing, please use the **dev api** since `/area-weighting-series-names` and` /area-weighting-series-names` are not yet available on stage/prod

merge is **blocked by the next prod release** which will enable the new endpoints created in https://grointelligence.atlassian.net/browse/GAIA-9994