### PR TITLE
GAIA-9469 Proxy Enviornment Variables for Tornado package

### DIFF
--- a/api/client/samples/batch_queries/batch_queries.py
+++ b/api/client/samples/batch_queries/batch_queries.py
@@ -1,8 +1,5 @@
 import os
-# change this import so it doesn't import from groclient but rather from the relative directory
-# from groclient import GroClient
-# you need to add /api-client to the PYTHONPATH envvar
-from groclient.client import GroClient
+from groclient import GroClient
 
 def main():
     # set up the Batch Client, same as normal Client
@@ -11,9 +8,11 @@ def main():
     ACCESS_TOKEN = os.environ['GROAPI_TOKEN']
     PROXY_HOST = os.getenv('PROXY_HOST')
     PROXY_PORT = os.getenv('PROXY_PORT')
+    PROXY_USERNAME = os.getenv('PROXY_USERNAME')
+    PROXY_PASS = os.getenv('PROXY_PASS')
     if isinstance(PROXY_PORT, str):
         PROXY_PORT = int(PROXY_PORT)
-    api_client = GroClient(API_HOST, ACCESS_TOKEN, PROXY_HOST, PROXY_PORT)
+    api_client = GroClient(API_HOST, ACCESS_TOKEN, PROXY_HOST, PROXY_PORT, PROXY_USERNAME, PROXY_PASS)
 
     # specify everything except region_id
     selection = {

--- a/api/client/samples/batch_queries/batch_queries.py
+++ b/api/client/samples/batch_queries/batch_queries.py
@@ -1,13 +1,17 @@
 import os
-from groclient import GroClient
+# change this import so it doesn't import from groclient but rather from the relative directory
+# from groclient import GroClient
+# you need to add /api-client to the PYTHONPATH envvar
+from groclient.client import GroClient
 
 def main():
     # set up the Batch Client, same as normal Client
     """ API Config """
     API_HOST = 'api.gro-intelligence.com'
     ACCESS_TOKEN = os.environ['GROAPI_TOKEN']
-
-    api_client = GroClient(API_HOST, ACCESS_TOKEN)
+    PROXY_HOST = '0.0.0.0'
+    PROXY_PORT = 8080
+    api_client = GroClient(API_HOST, ACCESS_TOKEN, PROXY_HOST, PROXY_PORT)
 
     # specify everything except region_id
     selection = {
@@ -39,6 +43,4 @@ def main():
             print("county_idx=%i has no data for 1998" % county_id)
 
 if __name__ == "__main__":
-        import pdb 
-        pdb.set_trace()
         main()

--- a/api/client/samples/batch_queries/batch_queries.py
+++ b/api/client/samples/batch_queries/batch_queries.py
@@ -39,4 +39,6 @@ def main():
             print("county_idx=%i has no data for 1998" % county_id)
 
 if __name__ == "__main__":
+        import pdb 
+        pdb.set_trace()
         main()

--- a/api/client/samples/batch_queries/batch_queries.py
+++ b/api/client/samples/batch_queries/batch_queries.py
@@ -9,8 +9,10 @@ def main():
     """ API Config """
     API_HOST = 'api.gro-intelligence.com'
     ACCESS_TOKEN = os.environ['GROAPI_TOKEN']
-    PROXY_HOST = '0.0.0.0'
-    PROXY_PORT = 8080
+    PROXY_HOST = os.getenv('PROXY_HOST')
+    PROXY_PORT = os.getenv('PROXY_PORT')
+    if isinstance(PROXY_PORT, str):
+        PROXY_PORT = int(PROXY_PORT)
     api_client = GroClient(API_HOST, ACCESS_TOKEN, PROXY_HOST, PROXY_PORT)
 
     # specify everything except region_id

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -57,7 +57,8 @@ class BatchError(APIError):
 
 class GroClient(object):
     """API client with stateful authentication for lib functions and extra convenience methods."""
-    def __init__(self, api_host=cfg.API_HOST, access_token=None, proxy_host=None, proxy_port=None):
+    def __init__(self, api_host=cfg.API_HOST, access_token=None, proxy_host=None, proxy_port=None,
+                 proxy_username=None, proxy_pass=None):
         """Construct a GroClient instance.
 
         Parameters
@@ -76,6 +77,11 @@ class GroClient(object):
             If you're instantiating the GroClient behind a proxy, you'll need to 
             provide the proxy_port to properly send requests using the groclient 
             library.
+        proxy_username : string, optional 
+            If you're instantiating the GroClient behind a proxy, and your proxy 
+            requires a username and password, you'll need to provide the proxy_username.
+        proxy_pass : string optional
+            Password for your proxy username.
 
         Raises
         ------
@@ -90,7 +96,8 @@ class GroClient(object):
             >>> client = GroClient(access_token="your_token_here")
             
             # example useage when accessed via a proxy
-            >>> client = GroClient(access_token="your_token_here", proxy_host="0.0.0.0", proxy_port=8080)
+            >>> client = GroClient(access_token="your_token_here", proxy_host="0.0.0.0", proxy_port=8080, 
+                                   proxy_username="user_name", proxy_pass="secret_password")
         """
         # Initialize early since they're referenced in the destructor and
         # access_token checking may cause constructor to exit early.
@@ -99,6 +106,8 @@ class GroClient(object):
 
         self._proxy_host = proxy_host
         self._proxy_port = proxy_port
+        self._proxy_username = proxy_username
+        self._proxy_pass = proxy_pass
 
         if access_token is None:
             access_token = os.environ.get("GROAPI_TOKEN")
@@ -119,6 +128,9 @@ class GroClient(object):
             if self._proxy_host and self._proxy_port:
                 defaults_dict = {"proxy_host": self._proxy_host,
                                  "proxy_port": self._proxy_port}
+                if self._proxy_username and self._proxy_pass:
+                    defaults_dict['proxy_username'] = self._proxy_username
+                    defaults_dict['proxy_pass'] = self._proxy_pass
                 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
                 self._async_http_client = AsyncHTTPClient(force_instance=True, defaults=defaults_dict)
             else:

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -97,7 +97,7 @@ class GroClient(object):
             
             # example useage when accessed via a proxy
             >>> client = GroClient(access_token="your_token_here", proxy_host="0.0.0.0", proxy_port=8080, 
-                                   proxy_username="user_name", proxy_pass="secret_password")
+            proxy_username="user_name", proxy_pass="secret_password")
         """
         # Initialize early since they're referenced in the destructor and
         # access_token checking may cause constructor to exit early.

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -68,7 +68,14 @@ class GroClient(object):
             Your Gro API authentication token. If not specified, the
             :code:`$GROAPI_TOKEN` environment variable is used. See
             :doc:`authentication`.
-        # TODO: add comments for new parameters
+        proxy_host : string, optional
+            If you're instantiating the GroClient behind a proxy, you'll need to 
+            provide the proxy_host to properly send requests using the groclient 
+            library.
+        proxy_port : int, optional
+            If you're instantiating the GroClient behind a proxy, you'll need to 
+            provide the proxy_port to properly send requests using the groclient 
+            library.
 
         Raises
         ------
@@ -81,14 +88,17 @@ class GroClient(object):
             >>> client = GroClient()  # token stored in $GROAPI_TOKEN
 
             >>> client = GroClient(access_token="your_token_here")
+            
+            # example useage when accessed via a proxy
+            >>> client = GroClient(access_token="your_token_here", proxy_host="0.0.0.0", proxy_port=8080)
         """
         # Initialize early since they're referenced in the destructor and
         # access_token checking may cause constructor to exit early.
         self._async_http_client = None
         self._ioloop = None
 
-        self.proxy_host = proxy_host
-        self.proxy_port = proxy_port
+        self._proxy_host = proxy_host
+        self._proxy_port = proxy_port
 
         if access_token is None:
             access_token = os.environ.get("GROAPI_TOKEN")
@@ -106,9 +116,9 @@ class GroClient(object):
             self._ioloop = IOLoop()
             # Note: force_instance is needed to disable Tornado's
             # pseudo-singleton AsyncHTTPClient caching behavior.
-            if self.proxy_host and self.proxy_port:
-                defaults_dict = {"proxy_host": self.proxy_host,
-                                "proxy_port": self.proxy_port}
+            if self._proxy_host and self._proxy_port:
+                defaults_dict = {"proxy_host": self._proxy_host,
+                                 "proxy_port": self._proxy_port}
                 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
                 self._async_http_client = AsyncHTTPClient(force_instance=True, defaults=defaults_dict)
             else:

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -87,6 +87,11 @@ class GroClient(object):
         self._async_http_client = None
         self._ioloop = None
 
+        # I think we'll need to add another if statement here to check for http_proxy and https_proxy env variables
+        # except we can't raise a runtime error if they aren't found because if the user isn't behind a proxy 
+        # then we don't want to raise an exception
+        # uh I think we will need to pass the http_proxy env var to the AsyncHTTPClient() object?
+
         if access_token is None:
             access_token = os.environ.get("GROAPI_TOKEN")
             if access_token is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ chardet
 future
 numpy
 pandas
+pycurl
 python-dateutil
 pytz
 requests


### PR DESCRIPTION
When an end user is using the api-client and they have to access the internet via a proxy, currently the Tornado `AsyncHTTPClient` was throwing errors because it requires `proxy_host` and `proxy_port` as parameters when being accessed via a proxy. 

This PR Updates `GroClient` to provide optional parameters, `proxy_host` and `proxy_port`, which are then passed to the `AsyncHTTPClient` which also is configured as a `CurlAsyncHTTPClient` class (otherwise the proxy variables won't work).

I tested this locally by installing `mitmproxy` with homebrew, and updating my wifi settings such that all requests/responses are routed through it. It runs on `localhost:8080`. I tested that the code works with and without setting the `PROXY_HOST` and `PROXY_PORT` environment variables.

Confirmed that setting the username and password was succesful with `mitmproxy --proxyauth any`:
![Screen Shot 2022-08-03 at 1 04 43 PM](https://user-images.githubusercontent.com/101421359/182669425-7e483c95-56bd-4e83-a759-f5160901150b.png)

Also this required installing `pycurl` so I'll need to update requirements.txt

```
$ pip install pycurl 
$ brew info openssl 
< set environment variables that it specifies >

For compilers to find openssl@3 you may need to set:
  export LDFLAGS="-L/usr/local/opt/openssl@3/lib"
  export CPPFLAGS="-I/usr/local/opt/openssl@3/include"

For pkg-config to find openssl@3 you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
```