### PR TITLE
Change the log level from error to warning.

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -347,7 +347,7 @@ class GroClient(object):
                 if len(missing_params) == 1
                 else ', '.join(missing_params[:-1]) + ' and ' + missing_params[-1] + ' are'
             )
-            self._logger.error(message)
+            self._logger.warning(message)
             raise ValueError(message)
 
         try:

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -566,7 +566,7 @@ def get_data_points(access_token, api_host, **selection):
             if len(missing_params) == 1
             else ', '.join(missing_params[:-1]) + ' and ' + missing_params[-1] + ' are'
         )
-        logger.error(message)
+        logger.warning(message)
         raise ValueError(message)
     resp = get_data(url, headers, params)
     include_historical = selection.get('include_historical', True)


### PR DESCRIPTION
Changed the log level to warning where there is a bad request.
I scanned the client and could find these two places where we could change the log level from error to warning.
I also scanned if there are any places where we should change from warning level to error level log but none such case exist.
