### PR TITLE
GAIA-11568 add param coverage_thresold to data calls

### DIFF
--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -372,7 +372,7 @@ def get_data_call_params(**selection):
             params['showHistory'] = value
         elif key in ('show_revisions', 'reporting_history'):
             params['showReportingDate'] = value
-        elif key in ('start_date', 'end_date', 'insert_null', 'at_time', 'available_since'):
+        elif key in ('start_date', 'end_date', 'insert_null', 'at_time', 'available_since', 'coverage_threshold'):
             params[groclient.utils.str_snake_to_camel(key)] = value
     params['responseType'] = 'list_of_series'
     return params

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -705,3 +705,34 @@ def test_get_area_weighted_series(mock_requests_get):
         )
         == expected_return
     )
+
+def test_get_data_call_params():
+    selections = {
+        'item_id': 3457,
+        'metric_id': 2540047,
+        'source_id': 26,
+        'frequency_id': 1,
+        'unit_id': 36,
+        'region_id': 102067,
+        'start_date': '2001-12-25',
+        'end_date': '2001-12-30',
+        'complete_history': True,
+        'at_time': '2018-01-01',
+        'show_metadata': True,
+        'coverage_threshold': 0.1
+    }
+    expected = {
+        'itemId': 3457,
+        'metricId': 2540047,
+        'sourceId': 26,
+        'frequencyId': 1,
+        'regionId': 102067,
+        'startDate': '2001-12-25',
+        'endDate': '2001-12-30',
+        'showHistory': True,
+        'atTime': '2018-01-01',
+        'showMetaData': True,
+        'coverageThreshold': 0.1,
+        'responseType': 'list_of_series'
+    }
+    assert(lib.get_data_call_params(**selections) == expected)


### PR DESCRIPTION
The API change is addressed in https://github.com/gro-intelligence/gro/pull/3367.
Note: The filtering by coverage feature is for internal use only. the documentation is not updated so that external users should not be aware of this change.