### PR TITLE
GAIA-13243 Update wheel distribution to remove `api/client/samples`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = "MIT"
 # TODO: remove once we remove the old api directory completely.
 packages = [
   { include = "groclient" },
-  { include = "api" },
 ]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ license = "MIT"
 # TODO: remove once we remove the old api directory completely.
 packages = [
   { include = "groclient" },
+  { include = "api" },
 ]
+exclude = ["api/client/samples"]
 
 [tool.poetry.scripts]
 gro_client = 'groclient.__main__:main'


### PR DESCRIPTION
Update wheel distribution to exclude `api/client/samples` to reduce the size of the wheel distribution that is downloaded by end users with `pip install groclient`

** Tested ** 

Before:
![Screen Shot 2022-11-14 at 1 55 20 PM](https://user-images.githubusercontent.com/101421359/201744950-045d4999-b80e-4597-8f4f-9457dd6c6cff.png)
![Screen Shot 2022-11-14 at 1 40 44 PM](https://user-images.githubusercontent.com/101421359/201745000-0fc29173-19a3-49bc-8129-2fa19612eb4a.png)


After:
![Screen Shot 2022-11-14 at 2 05 07 PM](https://user-images.githubusercontent.com/101421359/201744853-94047815-3811-42ba-9664-4d236360cbd3.png)
![Screen Shot 2022-11-14 at 2 05 00 PM](https://user-images.githubusercontent.com/101421359/201744901-7be6a31e-0933-412b-99ba-cfaa54c549c9.png)

