### PR TITLE
GAIA-16899 Multiple region ids for `get_area_weighted_series()`

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1703,7 +1703,7 @@ class GroClient(object):
         """
         return lib.get_area_weighting_weight_names(self.access_token, self.api_host)
 
-    def get_area_weighted_series(self, series_name, weight_names, region_id=None, region_ids=[], method='sum', latest_date_only=False):
+    def get_area_weighted_series(self, series_name, weight_names, region_id, method='sum', latest_date_only=False):
         """Compute weighted average on selected series with the given weights.
 
         Returns a dictionary mapping dates to weighted values.

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1703,7 +1703,7 @@ class GroClient(object):
         """
         return lib.get_area_weighting_weight_names(self.access_token, self.api_host)
 
-    def get_area_weighted_series(self, series_name, weight_names, region_id, method='sum', latest_date_only=False):
+    def get_area_weighted_series(self, series_name, weight_names, region_id=None, region_ids=[], method='sum', latest_date_only=False):
         """Compute weighted average on selected series with the given weights.
 
         Returns a dictionary mapping dates to weighted values.
@@ -1716,8 +1716,14 @@ class GroClient(object):
         weight_names: list of strs
             List of weight names that will be used to weight the provided series. e.g. ['Barley (ha)', 'Corn (ha)']
             For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
-        region_id: integer
+        region_id: integer, optional*
+            * Either `region_id` or `region_ids` must be specified. `region_ids` takes precedence over `region_id` if 
+            both are specified.
             The region for which the weighted series will be computed
+        region_ids: list of integers, optional*
+            * Either `region_id` or `region_ids` must be specified. `region_ids` takes precedence over `region_id` if 
+            both are specified.
+            The regions for which the weighted series will be computed
         method: str, optional
             'sum' by default. Multi-crop weights can be calculated with either 'sum' or 'normalize' method.
         latest_date_only: bool, optional
@@ -1732,5 +1738,5 @@ class GroClient(object):
                 {'2000-02-25': 0.217, '2000-03-04': 0.217, '2000-03-12': 0.221, ...}
         """
         return lib.get_area_weighted_series(
-            self.access_token, self.api_host, series_name, weight_names, region_id, method, latest_date_only
+            self.access_token, self.api_host, series_name, weight_names, region_id, region_ids, method, latest_date_only
         )

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -5,6 +5,8 @@ import json
 import os
 import time
 
+from typing import List, Union
+
 # Python3 support
 try:
     # Python3
@@ -1703,7 +1705,8 @@ class GroClient(object):
         """
         return lib.get_area_weighting_weight_names(self.access_token, self.api_host)
 
-    def get_area_weighted_series(self, series_name, weight_names, region_id, method='sum', latest_date_only=False):
+    def get_area_weighted_series(self, series_name: str, weight_names: List[str], region_id: Union[int, List[int]], 
+        method: str = 'sum', latest_date_only: bool = False):
         """Compute weighted average on selected series with the given weights.
 
         Returns a dictionary mapping dates to weighted values.
@@ -1718,6 +1721,7 @@ class GroClient(object):
             For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
         region_id: integer or list of integers
             The region or regions for which the weighted series will be computed
+            Supported region levels are (1, 2, 3, 4, 5, 8)
         method: str, optional
             'sum' by default. Multi-crop weights can be calculated with either 'sum' or 'normalize' method.
         latest_date_only: bool, optional

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1716,14 +1716,8 @@ class GroClient(object):
         weight_names: list of strs
             List of weight names that will be used to weight the provided series. e.g. ['Barley (ha)', 'Corn (ha)']
             For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
-        region_id: integer, optional*
-            * Either `region_id` or `region_ids` must be specified. `region_ids` takes precedence over `region_id` if 
-            both are specified.
-            The region for which the weighted series will be computed
-        region_ids: list of integers, optional*
-            * Either `region_id` or `region_ids` must be specified. `region_ids` takes precedence over `region_id` if 
-            both are specified.
-            The regions for which the weighted series will be computed
+        region_id: integer or list of integers
+            The region or regions for which the weighted series will be computed
         method: str, optional
             'sum' by default. Multi-crop weights can be calculated with either 'sum' or 'normalize' method.
         latest_date_only: bool, optional
@@ -1738,5 +1732,5 @@ class GroClient(object):
                 {'2000-02-25': 0.217, '2000-03-04': 0.217, '2000-03-12': 0.221, ...}
         """
         return lib.get_area_weighted_series(
-            self.access_token, self.api_host, series_name, weight_names, region_id, region_ids, method, latest_date_only
+            self.access_token, self.api_host, series_name, weight_names, region_id, method, latest_date_only
         )

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -570,6 +570,10 @@ class GroClientTests(TestCase):
             self.client.get_area_weighted_series('NDVI_8day', ['Barley (ha)', 'Corn (ha)'], 1215),
             {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
         )
+        self.assertEqual(
+            self.client.get_area_weighted_series('NDVI_8day', ['Barley (ha)', 'Corn (ha)'], [1215]),
+            {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
+        )
 
 class GroClientConstructorTests(TestCase):
     PROD_API_HOST = "api.gro-intelligence.com"

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -732,15 +732,15 @@ def get_area_weighting_weight_names(access_token, api_host):
     return resp.json()
 
 
-def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id, region_ids, method, latest_date_only):
+def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id, method, latest_date_only):
     url = f'https://{api_host}/area-weighting'
     headers = {'authorization': 'Bearer ' + access_token}
     if isinstance(region_id, int):
-        region_ids = [region_id]
+        region_id = [region_id]
     params = {
         'seriesName': series_name,
         'weightNames': weight_names,
-        'regionIds': region_ids,
+        'regionIds': region_id,
         'method': method,
         'latestDateOnly': latest_date_only,
     }

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -15,7 +15,10 @@ import logging
 import requests
 import time
 import platform
+
+
 from pkg_resources import get_distribution, DistributionNotFound
+from typing import List, Union
 
 try:
     # functools are native in Python 3.2.3+
@@ -732,7 +735,8 @@ def get_area_weighting_weight_names(access_token, api_host):
     return resp.json()
 
 
-def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id, method, latest_date_only):
+def get_area_weighted_series(access_token: str, api_host: str, series_name: str, weight_names: List[str], 
+                             region_id: Union[int, List[int]], method: str, latest_date_only: bool):
     url = f'https://{api_host}/area-weighting'
     headers = {'authorization': 'Bearer ' + access_token}
     if isinstance(region_id, int):

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -732,13 +732,15 @@ def get_area_weighting_weight_names(access_token, api_host):
     return resp.json()
 
 
-def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id, method, latest_date_only):
+def get_area_weighted_series(access_token, api_host, series_name, weight_names, region_id, region_ids, method, latest_date_only):
     url = f'https://{api_host}/area-weighting'
     headers = {'authorization': 'Bearer ' + access_token}
+    if isinstance(region_id, int):
+        region_ids = [region_id]
     params = {
         'seriesName': series_name,
         'weightNames': weight_names,
-        'regionId': region_id,
+        'regionIds': region_ids,
         'method': method,
         'latestDateOnly': latest_date_only,
     }

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -699,12 +699,12 @@ def test_get_area_weighted_series(mock_requests_get):
     initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
 
     expected_return = {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
-    assert (
-        lib.get_area_weighted_series(
-            MOCK_TOKEN, MOCK_HOST, 'NDVI_8day', ['Barley (ha)', 'Corn (ha)'], 1215, 'sum', False
-        )
-        == expected_return
-    )
+    result = lib.get_area_weighted_series(MOCK_TOKEN, MOCK_HOST, 'NDVI_8day', ['Barley (ha)', 'Corn (ha)'], 1215, 'sum', False)
+    assert result == expected_return
+
+    result = lib.get_area_weighted_series(MOCK_TOKEN, MOCK_HOST, 'NDVI_8day', ['Barley (ha)', 'Corn (ha)'], [1215], 'sum', False)
+    assert result == expected_return
+
 
 def test_get_data_call_params():
     selections = {


### PR DESCRIPTION
Solution:
* update region_id to accept either an int or list of ints

Tested:
* updated unit tests for `lib` and `client`

@jpaye used the following steps to do an integration test:
```
python3 -m poetry build
python3 -m pip uninstall groclient
python3 -m pip install groclient-0.0.0-py3-none-any.whl
client.get_area_weighted_series("GDI_daily", ["Corn"], [13066, 13065])
```