### PR TITLE
Add Reverse Geocoding API

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1738,3 +1738,36 @@ class GroClient(object):
         return lib.get_area_weighted_series(
             self.access_token, self.api_host, series_name, weight_names, region_id, method, latest_date_only
         )
+
+    def reverse_geocode_points(self, points: list):
+    """
+    Takes a list of lat/long pairs and return a list of corresponding Gro regions
+    Parameters
+    ----------
+    points: list[list[float]]
+    The list of points we want to reverse geocode. It is a list of points, where each point is a list with the lat/long pair
+    Example: `[[33.4484, -112.0740], [42.3314, -83.0458], [-8.8742, 125.7275]]`
+    Returns 
+    -------
+    A list of Python dictionaries, where each dictionary contains details for one of the passed points. The order is the same as the order of the passed points:
+    ```
+    [{'latitude': 33.4484, 
+      'longitude': -112.074, 
+      'l5_id': 136859, 
+      'l5_name': 'Maricopa', 
+      'l4_id': 13053, 
+      'l4_name': 'Arizona', 
+      'l3_id': 1215, 
+      'l3_name': 'United States'}, 
+     ...,
+     {'latitude': -8.8742, 
+      'longitude': 125.7275,
+      'l5_id': 134452,
+      'l5_name': 'Turiscai',
+      'l4_id': 12774,
+      'l4_name': 'Manufahi', 
+      'l3_id': 1199, 
+      'l3_name': 'East Timor'}]
+    ```
+    """
+        return lib.reverse_geocode_points(self.access_token, self.api_host, points)

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1740,34 +1740,36 @@ class GroClient(object):
         )
 
     def reverse_geocode_points(self, points: list):
-    """
-    Takes a list of lat/long pairs and return a list of corresponding Gro regions
-    Parameters
-    ----------
-    points: list[list[float]]
-    The list of points we want to reverse geocode. It is a list of points, where each point is a list with the lat/long pair
-    Example: `[[33.4484, -112.0740], [42.3314, -83.0458], [-8.8742, 125.7275]]`
-    Returns 
-    -------
-    A list of Python dictionaries, where each dictionary contains details for one of the passed points. The order is the same as the order of the passed points:
-    ```
-    [{'latitude': 33.4484, 
-      'longitude': -112.074, 
-      'l5_id': 136859, 
-      'l5_name': 'Maricopa', 
-      'l4_id': 13053, 
-      'l4_name': 'Arizona', 
-      'l3_id': 1215, 
-      'l3_name': 'United States'}, 
-     ...,
-     {'latitude': -8.8742, 
-      'longitude': 125.7275,
-      'l5_id': 134452,
-      'l5_name': 'Turiscai',
-      'l4_id': 12774,
-      'l4_name': 'Manufahi', 
-      'l3_id': 1199, 
-      'l3_name': 'East Timor'}]
-    ```
-    """
+        """
+        Takes a list of lat/long pairs and return a list of corresponding Gro regions
+
+        Parameters
+        ----------
+        points: list[list[float]]
+        The list of points we want to reverse geocode. Each point is a list containing the latitude and longitude
+        Example: `[[33.4484, -112.0740], [42.3314, -83.0458], [-8.8742, 125.7275]]`
+
+        Returns 
+        -------
+        A list of Python dictionaries, where each dictionary contains details for one of the passed points. The order is the same as the order of the passed points:
+        ```
+        [{'latitude': 33.4484, 
+          'longitude': -112.074, 
+          'l5_id': 136859, 
+          'l5_name': 'Maricopa', 
+          'l4_id': 13053, 
+          'l4_name': 'Arizona', 
+          'l3_id': 1215, 
+          'l3_name': 'United States'}, 
+         ...,
+         {'latitude': -8.8742, 
+          'longitude': 125.7275,
+          'l5_id': 134452,
+          'l5_name': 'Turiscai',
+          'l4_id': 12774,
+          'l4_name': 'Manufahi', 
+          'l3_id': 1199, 
+          'l3_name': 'East Timor'}]
+        ```
+        """
         return lib.reverse_geocode_points(self.access_token, self.api_host, points)

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -243,6 +243,8 @@ def mock_get_area_weighted_series(access_token, api_host, series_name, weight_na
                                   region_id, method, latest_date_only):
     return {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
 
+def mock_reverse_geocode_points(access_token, api_host, points):
+    return [{"latitude": 33.4484, "longitude": -112.074, "l5_id": 136859, "l5_name": "Maricopa", "l4_id": 13053, "l4_name": "Arizona", "l3_id": 1215, "l3_name": "United States"}, {"latitude": -8.8742, "longitude": 125.7275, "l5_id": 134452, "l5_name": "Turiscai", "l4_id": 12774, "l4_name": "Manufahi", "l3_id": 1199, "l3_name": "East Timor"}]  
 
 @patch("groclient.lib.get_available", MagicMock(side_effect=mock_get_available))
 @patch("groclient.lib.list_available", MagicMock(side_effect=mock_list_available))
@@ -270,6 +272,8 @@ def mock_get_area_weighted_series(access_token, api_host, series_name, weight_na
 @patch("groclient.lib.get_area_weighting_series_names", MagicMock(side_effect=mock_get_area_weighting_series_names))
 @patch("groclient.lib.get_area_weighting_weight_names", MagicMock(side_effect=mock_get_area_weighting_weight_names))
 @patch("groclient.lib.get_area_weighted_series", MagicMock(side_effect=mock_get_area_weighted_series))
+@patch("groclient.lib.reverse_geocode_points", MagicMock(side_effect=mock_reverse_geocode_points))
+
 class GroClientTests(TestCase):
     def setUp(self):
         self.client = GroClient(MOCK_HOST, MOCK_TOKEN)
@@ -574,6 +578,11 @@ class GroClientTests(TestCase):
             self.client.get_area_weighted_series('NDVI_8day', ['Barley (ha)', 'Corn (ha)'], [1215]),
             {'2022-07-11': 0.715615, '2022-07-19': 0.733129, '2022-07-27': 0.748822}
         )
+
+    def test_reverse_geocode_points(self):
+        self.assertEqual(
+            self.client.reverse_geocode_points([[33.4484, -112.0740], [-8.8742, 125.7275]]),
+            [{"latitude": 33.4484, "longitude": -112.074, "l5_id": 136859, "l5_name": "Maricopa", "l4_id": 13053, "l4_name": "Arizona", "l3_id": 1215, "l3_name": "United States"}, {"latitude": -8.8742, "longitude": 125.7275, "l5_id": 134452, "l5_name": "Turiscai", "l4_id": 12774, "l4_name": "Manufahi", "l3_id": 1199, "l3_name": "East Timor"}])
 
 class GroClientConstructorTests(TestCase):
     PROD_API_HOST = "api.gro-intelligence.com"

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -751,6 +751,17 @@ def get_area_weighted_series(access_token: str, api_host: str, series_name: str,
     resp = get_data(url, headers, params=params)
     return resp.json()
 
+def reverse_geocode_points(access_token: str, api_host: str, points: list):
+
+    # Don't need to send empty request to API
+    if len(points)==0:
+        return []
+    payload: dict = {'latlng': f"{points}"}
+    r = requests.post(f"https://{api_host}/v2/geocode", data=payload, headers={'Authorization': 'Bearer '+ access_token})
+    assert r.status_code == 200, f"Geocoding request failed with status code {r.status_code}"
+    return r.json()['data']
+
+
 
 if __name__ == '__main__':
     # To run doctests:

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -752,7 +752,6 @@ def get_area_weighted_series(access_token: str, api_host: str, series_name: str,
     return resp.json()
 
 def reverse_geocode_points(access_token: str, api_host: str, points: list):
-
     # Don't need to send empty request to API
     if len(points)==0:
         return []

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -705,6 +705,16 @@ def test_get_area_weighted_series(mock_requests_get):
     result = lib.get_area_weighted_series(MOCK_TOKEN, MOCK_HOST, 'NDVI_8day', ['Barley (ha)', 'Corn (ha)'], [1215], 'sum', False)
     assert result == expected_return
 
+@mock.patch('requests.post')
+def test_reverse_geocode_points(mock_requests_post):
+    expected_output = [{"latitude": 33.4484, "longitude": -112.074, "l5_id": 136859, "l5_name": "Maricopa", "l4_id": 13053, "l4_name": "Arizona", "l3_id": 1215, "l3_name": "United States"}, {"latitude": -8.8742, "longitude": 125.7275, "l5_id": 134452, "l5_name": "Turiscai", "l4_id": 12774, "l4_name": "Manufahi", "l3_id": 1199, "l3_name": "East Timor"}]
+    
+    initialize_requests_mocker_and_get_mock_data(mock_requests_post, {'data': expected_output})
+
+    result = lib.reverse_geocode_points(MOCK_TOKEN, MOCK_HOST, [[33.4484, -112.0740], [-8.8742, 125.7275]])
+    assert result == expected_output
+
+
 
 def test_get_data_call_params():
     selections = {
@@ -736,3 +746,4 @@ def test_get_data_call_params():
         'responseType': 'list_of_series'
     }
     assert(lib.get_data_call_params(**selections) == expected)
+


### PR DESCRIPTION
Clients are interested in using the reverse geocoding API to convert lat/long pairs to Gro regions

We already have a geocoding API, here we're just making it accessible in the client

- Adds the `reverse_geocode_points` method
    - Takes a list of points to geocode, returns a list of Gro regions
- Adds tests in both `client_test.py` and `lib_test.py`

Tested locally:

```
>>> client = GroClient()
>>> client.reverse_geocode_points([[33.4484, -112.0740], [42.3314, -83.0458], [-8.8742, 125.7275]])
[{'latitude': 33.4484, 'longitude': -112.074, 'l5_id': 136859, 'l5_name': 'Maricopa', 'l4_id': 13053, 'l4_name': 'Arizona', 'l3_id': 1215, 'l3_name': 'United States'}, {'latitude': 42.3314, 'longitude': -83.0458, 'l5_id': 138067, 'l5_name': 'Wayne', 'l4_id': 13073, 'l4_name': 'Michigan', 'l3_id': 1215, 'l3_name': 'United States'}, {'latitude': -8.8742, 'longitude': 125.7275, 'l5_id': 134452, 'l5_name': 'Turiscai', 'l4_id': 12774, 'l4_name': 'Manufahi', 'l3_id': 1199, 'l3_name': 'East Timor'}]
```