### PR TITLE
GAIA-20153- Add support for v2-prime api call

### DIFF
--- a/groclient/__init__.py
+++ b/groclient/__init__.py
@@ -1,5 +1,6 @@
 from groclient.client import GroClient
 from groclient.crop_model import CropModel
+from groclient.experimental import Experimental
 
 # Do a runtime lookup to get the groclient package version info.
 __version__ = lib.get_version_info().get('api-client-version', 'unknown')

--- a/groclient/constants.py
+++ b/groclient/constants.py
@@ -23,6 +23,15 @@ DATA_SERIES_UNIQUE_TYPES_ID = [
     'source_id'
 ]
 
+DATA_SERIES_UNIQUE_TYPES_ID_V2_PRIME = [
+    'itemIds',
+    'metricId',
+    'regionIds',
+    'partnerRegionIds',
+    'frequencyId',
+    'sourceId'
+]
+
 ENTITY_KEY_TO_TYPE = {
     'metric_id': 'metrics',
     'item_id': 'items',

--- a/groclient/constants.py
+++ b/groclient/constants.py
@@ -23,15 +23,6 @@ DATA_SERIES_UNIQUE_TYPES_ID = [
     'source_id'
 ]
 
-DATA_SERIES_UNIQUE_TYPES_ID_V2_PRIME = [
-    'itemIds',
-    'metricId',
-    'regionIds',
-    'partnerRegionIds',
-    'frequencyId',
-    'sourceId'
-]
-
 ENTITY_KEY_TO_TYPE = {
     'metric_id': 'metrics',
     'item_id': 'items',

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -33,7 +33,6 @@ class Experimental(GroClient):
                                     'source_id': 26,
                                     'start_date': '2021-12-20',
                                     'end_date': '2021-12-21',
-                                    'coverage_threshold': 0.9,
                                     'stream': True
                                     })
             Returns:
@@ -79,7 +78,7 @@ class Experimental(GroClient):
                 "meta": {
                     "version": "local",
                     "copyright": "Copyright (c) Gro Intelligence",
-                    "timestamp": "Mon, 03 Apr 2023 18:22:10 GMT"
+                    "timestamp": "Mon, 03 Apr 2023 18:32:53 GMT"
                 }
             }
         Parameters
@@ -103,6 +102,7 @@ class Experimental(GroClient):
         end_date : string, optional
             All points with start dates equal to or before this date
         coverage_threshold: float, optional
+            custom threshold on the coverage of geospatial data
         stream: bool, optional
 
         Returns

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -1,0 +1,115 @@
+from groclient.client import GroClient
+from groclient import lib
+
+
+class Experimental(GroClient):
+    """
+    Experimental class to consume v2prime data.
+    """
+    # Query parameters other than these are ignored.
+    ALLOWED_SELECTIONS = {
+        'item_ids',
+        'region_ids',
+        'metric_id',
+        'partner_region_ids',
+        'frequency_id',
+        'source_id',
+        'start_date',
+        'end_date',
+        'unit_Id',
+        'stream',
+        'coverage_threshold',
+                          }
+
+    def get_data_points(self, **selections):
+        """
+        Get all the data points for a given selection from v2prime/data.
+        Similar to groclient's get_data_points() for v2/data.
+        Example:
+            experimental_client.get_data_points(**{'metric_id': 2540047,
+                                    'item_ids': [3457],
+                                    'region_ids': [100023971, 100023990],
+                                    'frequency_id': 1,
+                                    'source_id': 26,
+                                    'start_date': '2021-12-20',
+                                    'end_date': '2021-12-22',
+                                    'coverage_threshold': 0.9,
+                                    'stream': True
+                                    })
+            Returns:
+            {
+                "data_series": [
+                    {
+                        "data_points": [
+                            {
+                                "timestamp_sec": "1640044800",
+                                "value": 33.20465087890625,
+                                "start_timestamp": "1639958400",
+                                "end_timestamp": "1640044800"
+                            }
+                        ],
+                        "series_description": {
+                            "source_id": 26,
+                            "item_id": 3457,
+                            "metric_id": 2540047,
+                            "frequency_id": 1,
+                            "region_id": 100023971,
+                            "unit_id": 36
+                        }
+                    },
+                    {
+                        "data_points": [
+                            {
+                                "timestamp_sec": "1640044800",
+                                "value": 32.73432922363281,
+                                "start_timestamp": "1639958400",
+                                "end_timestamp": "1640044800"
+                            }
+                        ],
+                        "series_description": {
+                            "source_id": 26,
+                            "item_id": 3457,
+                            "metric_id": 2540047,
+                            "frequency_id": 1,
+                            "region_id": 100023990,
+                            "unit_id": 36
+                        }
+                    }
+                ],
+                "meta": {
+                    "version": "local",
+                    "copyright": "Copyright (c) Gro Intelligence",
+                    "timestamp": "Mon, 03 Apr 2023 17:38:54 GMT"
+                }
+            }
+        Parameters
+        ----------
+         metric_id : integer
+            How something is measured. e.g. "Export Value" or "Area Harvested"
+        item_ids : integer or list of integers
+            What is being measured. e.g. "Corn" or "Rainfall"
+        region_ids : integer or list of integers
+            Where something is being measured e.g. "United States Corn Belt" or "China"
+        partner_region_ids : integer or list of integers, optional
+            partner_region refers to an interaction between two regions, like trade or
+            transportation. For example, for an Export metric, the "region" would be the exporter
+            and the "partner_region" would be the importer. For most series, this can be excluded
+            or set to 0 ("World") by default.
+        source_id : integer
+        frequency_id : integer
+        unit_id : integer, optional
+        start_date : string, optional
+            All points with end dates equal to or after this date
+        end_date : string, optional
+            All points with start dates equal to or before this date
+        coverage_threshold: float, optional
+        stream: bool, optional
+
+        Returns
+        -------
+
+        dict of data_series containing data points and its description as shown in above example.
+
+        """
+        return lib.get_data_points_v2_prime(self.access_token, self.api_host, Experimental.ALLOWED_SELECTIONS,
+                                            **selections)

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -6,21 +6,6 @@ class Experimental(GroClient):
     """
     Experimental class to consume v2prime data.
     """
-    # Query parameters other than these are ignored.
-    ALLOWED_SELECTIONS = {
-        'item_ids',
-        'region_ids',
-        'metric_id',
-        'partner_region_ids',
-        'frequency_id',
-        'source_id',
-        'start_date',
-        'end_date',
-        'unit_Id',
-        'stream',
-        'coverage_threshold',
-                          }
-
     def get_data_points(self, **selections):
         """
         Get all the data points for a given selection from /v2prime/data.
@@ -111,5 +96,5 @@ class Experimental(GroClient):
         dict of data_series containing data points and its description as shown in above example.
 
         """
-        return lib.get_data_points_v2_prime(self.access_token, self.api_host, Experimental.ALLOWED_SELECTIONS,
+        return lib.get_data_points_v2_prime(self.access_token, self.api_host,
                                             **selections)

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -18,7 +18,7 @@ class Experimental(GroClient):
                                     'source_id': 26,
                                     'start_date': '2021-12-20',
                                     'end_date': '2021-12-21',
-                                    'stream': True
+                                    'stream': False
                                     })
             Returns:
             {
@@ -63,7 +63,7 @@ class Experimental(GroClient):
                 "meta": {
                     "version": "local",
                     "copyright": "Copyright (c) Gro Intelligence",
-                    "timestamp": "Mon, 03 Apr 2023 18:32:53 GMT"
+                    "timestamp": "Mon, 03 Apr 2023 19:34:38 GMT"
                 }
             }
         Parameters
@@ -96,5 +96,4 @@ class Experimental(GroClient):
         dict of data_series containing data points and its description as shown in above example.
 
         """
-        return lib.get_data_points_v2_prime(self.access_token, self.api_host,
-                                            **selections)
+        return lib.get_data_points_v2_prime(self.access_token, self.api_host, **selections)

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -87,7 +87,7 @@ class Experimental(GroClient):
         end_date : string, optional
             All points with start dates equal to or before this date
         coverage_threshold: float, optional
-            custom threshold on the coverage of geospatial data
+            Custom threshold on the coverage of geospatial data. Value should be between 0 and 1.
         stream: bool, optional
 
         Returns

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -23,8 +23,8 @@ class Experimental(GroClient):
 
     def get_data_points(self, **selections):
         """
-        Get all the data points for a given selection from v2prime/data.
-        Similar to groclient's get_data_points() for v2/data.
+        Get all the data points for a given selection from /v2prime/data.
+
         Example:
             experimental_client.get_data_points(**{'metric_id': 2540047,
                                     'item_ids': [3457],
@@ -32,7 +32,7 @@ class Experimental(GroClient):
                                     'frequency_id': 1,
                                     'source_id': 26,
                                     'start_date': '2021-12-20',
-                                    'end_date': '2021-12-22',
+                                    'end_date': '2021-12-21',
                                     'coverage_threshold': 0.9,
                                     'stream': True
                                     })
@@ -79,7 +79,7 @@ class Experimental(GroClient):
                 "meta": {
                     "version": "local",
                     "copyright": "Copyright (c) Gro Intelligence",
-                    "timestamp": "Mon, 03 Apr 2023 17:38:54 GMT"
+                    "timestamp": "Mon, 03 Apr 2023 18:22:10 GMT"
                 }
             }
         Parameters

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -578,7 +578,7 @@ def get_data_points(access_token, api_host, **selection):
 
 def get_data_points_v2_prime(access_token, api_host, **selection):
     headers = {'authorization': 'Bearer ' + access_token}
-    url = '/'.join(['http:', '', api_host, 'v2prime/data'])
+    url = '/'.join(['https:', '', api_host, 'v2prime/data'])
     params = {}
     for key, value in list(selection.items()):
         params[groclient.utils.str_snake_to_camel(key)] = value

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -587,7 +587,7 @@ def parse_params(allowed_selections, **selections):
 def get_data_points_v2_prime(access_token, api_host, allowed_selections, **selection):
     logger = get_default_logger()
     headers = {'authorization': 'Bearer ' + access_token}
-    url = '/'.join(['http:', '', api_host, 'v2prime/data'])
+    url = '/'.join(['https:', '', api_host, 'v2prime/data'])
     params = parse_params(allowed_selections, **selection)
 
     required_params = [

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -8,7 +8,7 @@ than here.
 from builtins import str
 from groclient import cfg
 from collections import OrderedDict
-from groclient.constants import REGION_LEVELS, DATA_SERIES_UNIQUE_TYPES_ID, DATA_SERIES_UNIQUE_TYPES_ID_V2_PRIME
+from groclient.constants import REGION_LEVELS, DATA_SERIES_UNIQUE_TYPES_ID
 import groclient.utils
 import json
 import logging
@@ -576,50 +576,12 @@ def get_data_points(access_token, api_host, **selection):
     return list_of_series_to_single_series(resp.json(), False, include_historical)
 
 
-def parse_params(**selections):
-    logger = get_default_logger()
-    # Query parameters other than allowed_selections are ignored.
-    allowed_selections = {
-        'item_ids',
-        'region_ids',
-        'metric_id',
-        'partner_region_ids',
-        'frequency_id',
-        'source_id',
-        'start_date',
-        'end_date',
-        'unit_id',
-        'stream',
-        'coverage_threshold',
-                          }
-    required_parameters = {
-        'itemIds',
-        'metricId',
-        'regionIds',
-        'frequencyId',
-        'sourceId'
-                           }
-    params = {}
-    for key, value in list(selections.items()):
-        if key in allowed_selections:
-            params[groclient.utils.str_snake_to_camel(key)] = value
-    missing_required_parameters = required_parameters - params.keys()
-    if missing_required_parameters:
-        missing_required_parameters = list(missing_required_parameters)
-        message = 'API request cannot be processed because {} not specified.'.format(
-            missing_required_parameters[0] + ' is'
-            if len(missing_required_parameters) == 1
-            else ', '.join(missing_required_parameters[:-1]) + ' and ' + missing_required_parameters[-1] + ' are'
-        )
-        logger.warning(message)
-        raise ValueError(message)
-    return params
-
-
 def get_data_points_v2_prime(access_token, api_host, **selection):
     headers = {'authorization': 'Bearer ' + access_token}
-    url = '/'.join(['https:', '', api_host, 'v2prime/data'])
-    params = parse_params(**selection)
+    url = '/'.join(['http:', '', api_host, 'v2prime/data'])
+    params = {}
+    for key, value in list(selection.items()):
+        params[groclient.utils.str_snake_to_camel(key)] = value
     resp = get_data(url, headers, params)
     return resp.json()
 


### PR DESCRIPTION
**Goal/Problem**
Add `v2prime` API call support to python SDK.

**Solution**
Create a new experimental class that has function to call `v2Prime` endpoint.

**Tested**
Tested in local, able to get same data from API (from postman) and SDK.
```
exp = Experimental('localhost:3000', token)
exp_output = exp.get_data_points(**{'metric_id': 2540047,
                                    'item_ids': 3457,
                                    'region_ids': [100023971, 100023990],
                                    'frequency_id': 1,
                                    'source_id': 26,
                                    'start_date': '2021-12-20',
                                    'end_date': '2021-12-22',
                                    'stream': True,
                                    })
```