### PR TITLE
Gaia 20447 - Add developers docs for experimental v2 prime get_data_points function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,3 +81,9 @@ Crop Modeling
 .. automethod:: groclient.CropModel.compute_gdd
 
 .. automethod:: groclient.CropModel.growing_degree_days
+
+=============
+Experimental
+=============
+
+.. automethod:: groclient.Experimental.get_data_points

--- a/docs/prerequisites/anaconda-additional-information.rst
+++ b/docs/prerequisites/anaconda-additional-information.rst
@@ -9,7 +9,7 @@ Anaconda Additional Information
 
 #. If your username includes spaces, as is common on Windows systems, you are not allowed to install Anaconda in the default path (C:\Users\<your-username>\Anaconda3\)
 
-	a. See this `Anaconda link <https://docs.anaconda.com/anaconda/user-guide/faq/>`_ for additional information.
+	a. See this `Anaconda link <https://docs.anaconda.com/free/anaconda/reference/faq/>`_ for additional information.
 
 #. If you install Anaconda outside of the default path, then you will need to update the config for the jupyter notebook default directory as outlined below:
 

--- a/docs/prerequisites/anaconda-additional-information.rst
+++ b/docs/prerequisites/anaconda-additional-information.rst
@@ -27,6 +27,6 @@ Anaconda Additional Information
 	f. Relaunch Anaconda Navigator
 	g. Launch jupyter notebook
 
-#. See the following link from Anaconda if you have a `proxy <https://docs.anaconda.com/anaconda/user-guide/tasks/proxy/>`_
+#. See the following link from Anaconda if you have a `proxy <https://enterprise-docs.anaconda.com/en/latest/admin/chan-pkg/proxy.html>`_
 #. See the following link from Anaconda if you have a `firewall <https://docs.anaconda.com/anaconda-enterprise-4/ae-and-nav/#configuring-firewall-settings>`_
 

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -7,6 +7,7 @@ class Experimental(GroClient):
 
     def get_data_points(self, **selections):
         """Get all the data points for a given selection from /v2prime/data.
+
         Note - This function is a part of an experimental class and subject to change.
 
         Parameters
@@ -40,18 +41,19 @@ class Experimental(GroClient):
 
             Example::
 
-            exp_client = Experimental(api.gro-intelligence.com, GROAPI_TOKEN)
+            exp_client = Experimental("api.gro-intelligence.com", GROAPI_TOKEN)
             exp_client.get_data_points(
-            **{
-            'metric_id': 2540047,
-            'item_ids': [3457],
-            'region_ids': [100023971, 100023990],
-            'frequency_id': 1,
-            'source_id': 26,
-            'start_date': '2021-12-20',
-            'end_date': '2021-12-21',
-            'stream': False
-            })
+                **{
+                    'metric_id': 2540047,
+                    'item_ids': [3457],
+                    'region_ids': [100023971, 100023990],
+                    'frequency_id': 1,
+                    'source_id': 26,
+                    'start_date': '2021-12-20',
+                    'end_date': '2021-12-21',
+                    'stream': False
+                    }
+            )
             Returns:
             {
                 "data_series": [

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -10,6 +10,7 @@ class Experimental(GroClient):
     def get_data_points(self, **selections):
         """
         Get all the data points for a given selection from /v2prime/data.
+        Note: This function is a part of an experimental class and subject to change.
 
         Example:
             experimental_client.get_data_points(**{'metric_id': 2540047,
@@ -27,7 +28,6 @@ class Experimental(GroClient):
                     {
                         "data_points": [
                             {
-                                "timestamp_sec": "1640044800",
                                 "value": 33.20465087890625,
                                 "start_timestamp": "1639958400",
                                 "end_timestamp": "1640044800"
@@ -45,7 +45,6 @@ class Experimental(GroClient):
                     {
                         "data_points": [
                             {
-                                "timestamp_sec": "1640044800",
                                 "value": 32.73432922363281,
                                 "start_timestamp": "1639958400",
                                 "end_timestamp": "1640044800"
@@ -62,9 +61,9 @@ class Experimental(GroClient):
                     }
                 ],
                 "meta": {
-                    "version": "local",
+                    "version": "v1.266.0",
                     "copyright": "Copyright (c) Gro Intelligence",
-                    "timestamp": "Mon, 03 Apr 2023 19:34:38 GMT"
+                    "timestamp": "Wed, 19 Apr 2023 14:34:05 GMT"
                 }
             }
         Parameters

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -8,7 +8,7 @@ class Experimental(GroClient):
     def get_data_points(self, **selections):
         """Get all the data points for a given selection from /v2prime/data.
 
-        Note - This function is a part of an experimental class and subject to change.
+        This function is a part of an experimental class and subject to change.
 
         Parameters
         ----------
@@ -36,25 +36,27 @@ class Experimental(GroClient):
 
         Returns
         -------
+            dict
+                dictionary containing list of data_points and series_description
 
-        dict of data_series containing data points and its description as shown in above example.
+        Example::
 
-            Example::
-
-            exp_client = Experimental("api.gro-intelligence.com", GROAPI_TOKEN)
+            exp_client = Experimental(access_token="your_token_here")
             exp_client.get_data_points(
-                **{
-                    'metric_id': 2540047,
-                    'item_ids': [3457],
-                    'region_ids': [100023971, 100023990],
-                    'frequency_id': 1,
-                    'source_id': 26,
-                    'start_date': '2021-12-20',
-                    'end_date': '2021-12-21',
-                    'stream': False
-                    }
-            )
-            Returns:
+                                    **{
+                                        'metric_id': 2540047,
+                                        'item_ids': [3457],
+                                        'region_ids': [100023971, 100023990],
+                                        'frequency_id': 1,
+                                        'source_id': 26,
+                                        'start_date': '2021-12-20',
+                                        'end_date': '2021-12-21',
+                                        'stream': False
+                                    }
+                                )
+
+        Returns::
+
             {
                 "data_series": [
                     {

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -3,12 +3,20 @@ from groclient import lib
 
 
 class Experimental(GroClient):
-    """Experimental class to consume v2prime data."""
+    """The experimental client will introduce a range of experimental functions with better user experience.
+    While you will be able to access better performance and new features at an early stage,
+    you should be aware that things might change (e.g response format)."""
 
     def get_data_points(self, **selections):
-        """Get all the data points for a given selection from /v2prime/data.
+        """This function is a mirror of existing :meth:`~groclient.GroClient.get_data_points`, but with limited scope.
 
-        This function is a part of an experimental class and subject to change.
+        For example:
+
+        - Ontology expansion is under development.
+
+        - "Gro derived on-the-fly" is under development.
+
+        - Many sources are still under migration (please refer to internal confluence page for source migration timeline)
 
         Parameters
         ----------
@@ -27,12 +35,11 @@ class Experimental(GroClient):
         frequency_id : integer
         unit_id : integer, optional
         start_date : string, optional
-            All points with end dates equal to or after this date
+            All data points with end dates after this date.
         end_date : string, optional
-            All points with start dates equal to or before this date
+            All data points with start dates before this date.
         coverage_threshold: float, optional
             Custom threshold on the coverage of geospatial data. Value should be between 0 and 1.
-        stream: bool, optional
 
         Returns
         -------
@@ -51,7 +58,6 @@ class Experimental(GroClient):
                                         'source_id': 26,
                                         'start_date': '2021-12-20',
                                         'end_date': '2021-12-21',
-                                        'stream': False
                                     }
                                 )
 

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -13,15 +13,19 @@ class Experimental(GroClient):
         Note: This function is a part of an experimental class and subject to change.
 
         Example:
-            experimental_client.get_data_points(**{'metric_id': 2540047,
-                                    'item_ids': [3457],
-                                    'region_ids': [100023971, 100023990],
-                                    'frequency_id': 1,
-                                    'source_id': 26,
-                                    'start_date': '2021-12-20',
-                                    'end_date': '2021-12-21',
-                                    'stream': False
-                                    })
+            exp_client = Experimental(api.gro-intelligence.com, GROAPI_TOKEN)
+            exp_client.get_data_points(
+            **{
+                'metric_id': 2540047,
+                'item_ids': [3457],
+                'region_ids': [100023971, 100023990],
+                'frequency_id': 1,
+                'source_id': 26,
+                'start_date': '2021-12-20',
+                'end_date': '2021-12-21',
+                'stream': False
+                }
+            )
             Returns:
             {
                 "data_series": [

--- a/groclient/experimental.py
+++ b/groclient/experimental.py
@@ -3,29 +3,55 @@ from groclient import lib
 
 
 class Experimental(GroClient):
-    """
-    Experimental class to consume v2prime data.
-    """
+    """Experimental class to consume v2prime data."""
 
     def get_data_points(self, **selections):
-        """
-        Get all the data points for a given selection from /v2prime/data.
-        Note: This function is a part of an experimental class and subject to change.
+        """Get all the data points for a given selection from /v2prime/data.
+        Note - This function is a part of an experimental class and subject to change.
 
-        Example:
+        Parameters
+        ----------
+        metric_id : integer
+            How something is measured. e.g. "Export Value" or "Area Harvested"
+        item_ids : integer or list of integers
+            What is being measured. e.g. "Corn" or "Rainfall"
+        region_ids : integer or list of integers
+            Where something is being measured e.g. "United States Corn Belt" or "China"
+        partner_region_ids : integer or list of integers, optional
+            partner_region refers to an interaction between two regions, like trade or
+            transportation. For example, for an Export metric, the "region" would be the exporter
+            and the "partner_region" would be the importer. For most series, this can be excluded
+            or set to 0 ("World") by default.
+        source_id : integer
+        frequency_id : integer
+        unit_id : integer, optional
+        start_date : string, optional
+            All points with end dates equal to or after this date
+        end_date : string, optional
+            All points with start dates equal to or before this date
+        coverage_threshold: float, optional
+            Custom threshold on the coverage of geospatial data. Value should be between 0 and 1.
+        stream: bool, optional
+
+        Returns
+        -------
+
+        dict of data_series containing data points and its description as shown in above example.
+
+            Example::
+
             exp_client = Experimental(api.gro-intelligence.com, GROAPI_TOKEN)
             exp_client.get_data_points(
             **{
-                'metric_id': 2540047,
-                'item_ids': [3457],
-                'region_ids': [100023971, 100023990],
-                'frequency_id': 1,
-                'source_id': 26,
-                'start_date': '2021-12-20',
-                'end_date': '2021-12-21',
-                'stream': False
-                }
-            )
+            'metric_id': 2540047,
+            'item_ids': [3457],
+            'region_ids': [100023971, 100023990],
+            'frequency_id': 1,
+            'source_id': 26,
+            'start_date': '2021-12-20',
+            'end_date': '2021-12-21',
+            'stream': False
+            })
             Returns:
             {
                 "data_series": [
@@ -70,35 +96,6 @@ class Experimental(GroClient):
                     "timestamp": "Wed, 19 Apr 2023 14:34:05 GMT"
                 }
             }
-        Parameters
-        ----------
-         metric_id : integer
-            How something is measured. e.g. "Export Value" or "Area Harvested"
-        item_ids : integer or list of integers
-            What is being measured. e.g. "Corn" or "Rainfall"
-        region_ids : integer or list of integers
-            Where something is being measured e.g. "United States Corn Belt" or "China"
-        partner_region_ids : integer or list of integers, optional
-            partner_region refers to an interaction between two regions, like trade or
-            transportation. For example, for an Export metric, the "region" would be the exporter
-            and the "partner_region" would be the importer. For most series, this can be excluded
-            or set to 0 ("World") by default.
-        source_id : integer
-        frequency_id : integer
-        unit_id : integer, optional
-        start_date : string, optional
-            All points with end dates equal to or after this date
-        end_date : string, optional
-            All points with start dates equal to or before this date
-        coverage_threshold: float, optional
-            Custom threshold on the coverage of geospatial data. Value should be between 0 and 1.
-        stream: bool, optional
-
-        Returns
-        -------
-
-        dict of data_series containing data points and its description as shown in above example.
-
         """
         return lib.get_data_points_v2_prime(
             self.access_token, self.api_host, **selections


### PR DESCRIPTION
**Goal**
We have `Experimental` class that we can use to access the v2prime data.
We want to add the documentation to the function `get_data_points` of the `Experimental` class.

**Solution**
Add the documentation and make it visible under [https://developers.gro-intelligence.com/api.html](https://developers.gro-intelligence.com/api.html).

**Tested**
Works on my local. (Updated following image)
![image](https://user-images.githubusercontent.com/102551545/233419137-d4f91245-2b90-478d-90a4-9d7a0a71852b.png)


Notes to reviewer:

Seems like if you tag a commit, the `CD` automatically releases a new version? I was tagging a commit in my branch to see if only the docs gets published but ended up having a code release. Has no code change in that commit so it isn't a problem. Hopefully the prod release includes the permission for v2 prime tomorrow. Will merge this and release a new version manually after review.
