### PR TITLE
GAIA-21107 Add support for area weighting metadata 

### DIFF
--- a/docs/data-point-definition.md
+++ b/docs/data-point-definition.md
@@ -25,7 +25,7 @@ Below are some explanations of what each of those fields represent:
 * `start_date`: beginning of the period this point represents
 * `end_date`: end of the period this point represents
 * `value`: the value, typically a number. In some cases, the value may be non-numeric. E.g., when the metric is Crop Calendar, a value of "planting," represents the fact that the planting period is from `start_date` to `end_date`.
-* `unit_id`: this is a Gro unit id you can look up the name/abbreviation/etc. of using the `client.lookup('units', unit_id)` function. There's also a helper function of which you can see an example in the [quickstart](https://github.com/gro-intelligence/api-client/blob/9c2c17642980b5415b8a8167a28276b77e34915c/api/client/samples/quick_start.py#L30) for getting just the abbreviation from the unit id, `client.lookup_unit_abbreviation(point['unit_id'])`, which is the common case you probably want
+* `unit_id`: this is a Gro unit id you can look up the name/abbreviation/etc. of using the `client.lookup('units', unit_id)` function. There's also a helper function of which you can see an example in the [quickstart](https://github.com/gro-intelligence/api-client/blob/9c2c17642980b5415b8a8167a28276b77e34915c/api/client/samples/quick_start.py) for getting just the abbreviation from the unit id, `client.lookup_unit_abbreviation(point['unit_id'])`, which is the common case you probably want
 * `metadata`: additional information (i.e. {"conf_interval": 0.7})
 * `reporting_date`: date when the source reported this value (`None` if the source doesn't provide a reporting date)
 * `available_date`: date when this value became stable in Gro's system

--- a/docs/prerequisites/software-packages-prereqs.rst
+++ b/docs/prerequisites/software-packages-prereqs.rst
@@ -23,7 +23,7 @@ The Gro API Client package is supported both with or without Anaconda. However, 
 
 Anaconda
 --------
-1. Download Anaconda with Python 3.5 or above from `anaconda.com <https://www.anaconda.com/distribution/>`_ Support for Python 2.7.13 or above is also maintained, but with `its End of Life <https://mail.python.org/pipermail/python-dev/2018-March/152348.html>`_, it is recommended you start with Python 3.
+1. Download Anaconda with Python 3.5 or above from `anaconda.com <https://www.anaconda.com/download>`_ Support for Python 2.7.13 or above is also maintained, but with `its End of Life <https://mail.python.org/pipermail/python-dev/2018-March/152348.html>`_, it is recommended you start with Python 3.
 2. Install Git from `git-scm.com <https://git-scm.com/download/win>`_. Proceed with the default options.
 3. See `additional information <./anaconda-additional-information>`_ related to Anaconda if Anaconda is not installed in the default directory (C:\\Users\\<your-username>) or if your environment uses a proxy or firewall in connections to the internet.
 

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1868,8 +1868,7 @@ class GroClient(object):
         metadata_type: str
             Type of entity. i.e. either series or weight. e.g. 'series'
         names: list of strs
-            List of series or weight names for which to get the metadata. e.g. ['Barley (ha)', 'Corn (ha)']
-            For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
+            List of series or weight names for which to get the metadata. e.g. ['GDI_daily', 'LST_daily']
         Returns
         -------
         dict

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1854,21 +1854,18 @@ class GroClient(object):
             latest_date_only,
         )
 
-    def get_area_weighting_metadata(
+    def get_area_weighting_weight_metadata(
         self,
-        metadata_type: str,
         names: List[str],
     ):
-        """Get metadata of series or weights used in the area-weighting service.
+        """Get metadata of weight/s used in the area-weighting service.
 
-        Returns a list of dictionary mapping series/weight names to its metadata.
+        Returns a list of dictionary mapping weight names to its metadata.
 
         Parameters
         ----------
-        metadata_type: str
-            Type of entity. i.e. either series or weight. e.g. 'series'
         names: list of strs
-            List of series or weight names for which to get the metadata. e.g. ['GDI_daily', 'LST_daily']
+            List of weight for which to get the metadata. e.g. ['Wheat', 'Canola']
         Returns
         -------
         dict
@@ -1886,7 +1883,42 @@ class GroClient(object):
         return lib.get_area_weighting_metadata(
             self.access_token,
             self.api_host,
-            metadata_type,
+            "weight",
+            names,
+        )
+
+    def get_area_weighting_series_metadata(
+        self,
+        names: List[str],
+    ):
+        """Get metadata of series used in the area-weighting service.
+
+        Returns a list of dictionary mapping series names to its metadata.
+
+        Parameters
+        ----------
+        names: list of strs
+            List of series for which to get the metadata. e.g. ['GDI_daily', 'LST_daily']
+        Returns
+        -------
+        dict
+
+            Example::
+                    [{
+                    "series_name": "GFS_tmax_daily_yesterday",
+                    "item_id": 2177,
+                    "metric_id": 2540047,
+                    "source_id": 105,
+                    "frequency_id": 1,
+                    "unit_id": "36",
+                    "plain_words_name": "Max Temperature Forecast - Yesterday",
+                    "plain_words_source": "GFS"
+                    }]
+        """
+        return lib.get_area_weighting_metadata(
+            self.access_token,
+            self.api_host,
+            "series",
             names,
         )
 

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1854,6 +1854,43 @@ class GroClient(object):
             latest_date_only,
         )
 
+    def get_area_weighting_metadata(
+        self,
+        metadata_type: str,
+        names: List[str],
+    ):
+        """Get metadata of series or weights used in the area-weighting service.
+
+        Returns a list of dictionary mapping series/weight names to its metadata.
+
+        Parameters
+        ----------
+        metadata_type: str
+            Type of entity. i.e. either series or weight. e.g. 'series'
+        names: list of strs
+            List of series or weight names for which to get the metadata. e.g. ['Barley (ha)', 'Corn (ha)']
+            For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
+        Returns
+        -------
+        dict
+
+            Example::
+                    [{
+                    "column_name": "Wheat",
+                    "metric_id": 2120001,
+                    "item_id": 95,
+                    "source_id": 88,
+                    "frequency_id": 15,
+                    "unit_id": 42
+                    }]
+        """
+        return lib.get_area_weighting_metadata(
+            self.access_token,
+            self.api_host,
+            metadata_type,
+            names,
+        )
+
     def reverse_geocode_points(self, points: list):
         """
         Takes a list of lat/long pairs and return a list of corresponding Gro regions

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -860,6 +860,24 @@ def get_area_weighted_series(
     return resp.json()
 
 
+def get_area_weighting_metadata(
+    access_token: str,
+    api_host: str,
+    metadata_type: str,
+    names: List[str],
+):
+    url = f"http://{api_host}/area-weighting-metadata"
+    headers = {"authorization": "Bearer " + access_token}
+    # if isinstance(region_id, int):
+    #     region_id = [region_id]
+    params = {
+        "metadataType": metadata_type,
+        "names": names,
+    }
+    resp = get_data(url, headers, params=params)
+    return resp.json()
+
+
 def reverse_geocode_points(access_token: str, api_host: str, points: list):
     # Don't need to send empty request to API
     if len(points) == 0:

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -866,10 +866,9 @@ def get_area_weighting_metadata(
     metadata_type: str,
     names: List[str],
 ):
-    url = f"https://{api_host}/area-weighting-metadata"
+    url = f"https://{api_host}/area-weighting/{metadata_type}-metadata"
     headers = {"authorization": "Bearer " + access_token}
     params = {
-        "metadataType": metadata_type,
         "names": names,
     }
     resp = get_data(url, headers, params=params)

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -866,7 +866,7 @@ def get_area_weighting_metadata(
     metadata_type: str,
     names: List[str],
 ):
-    url = f"http://{api_host}/area-weighting-metadata"
+    url = f"https://{api_host}/area-weighting-metadata"
     headers = {"authorization": "Bearer " + access_token}
     params = {
         "metadataType": metadata_type,

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -868,8 +868,6 @@ def get_area_weighting_metadata(
 ):
     url = f"http://{api_host}/area-weighting-metadata"
     headers = {"authorization": "Bearer " + access_token}
-    # if isinstance(region_id, int):
-    #     region_id = [region_id]
     params = {
         "metadataType": metadata_type,
         "names": names,


### PR DESCRIPTION
Goal/Problem

Add function to access the result from the area-weighting service metadata endpoint.

Solution

Add a new endpoint.

Python Checklist [[ref](https://grointelligence.atlassian.net/wiki/spaces/DC/pages/3086811185/Code+Documentation+Guide)]

Authors and reviewers, please begin adopting these checklist items

 Added [Google-style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) docstrings to new and modified functions (not starting with _)
 Added [type hints](https://google.github.io/styleguide/pyguide.html#221-type-annotated-code) to parameters and return for all new and modified functions
Tested
Works while pointed to dev api.
![image](https://github.com/gro-intelligence/api-client/assets/102551545/48793e15-5cd1-414a-a9af-297dfceac6d8)

Status / Notes to Reviewers (optional)

If you want some people to take a look at specific area of code, list them here with instructions Status: in progress/ready for review*