### PR TITLE
GAIA-21107 - column_name to weight_name in docstring bug fix

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1872,7 +1872,7 @@ class GroClient(object):
 
             Example::
                     [{
-                    "column_name": "Wheat",
+                    "weight_name": "Wheat",
                     "metric_id": 2120001,
                     "item_id": 95,
                     "source_id": 88,


### PR DESCRIPTION
**Problem**
The `/area-weighting/weight-metadata` endpoint output dictionary key for weight name is changed from `column_name` to `weight_name`.
**Solution**
Just update the docstring in the function.
**Tested**
No code change to test.