### PR TITLE
GAIA-20785 - Add metadata support on area weighted series

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1815,6 +1815,7 @@ class GroClient(object):
         region_id: Union[int, List[int]],
         method: str = "sum",
         latest_date_only: bool = False,
+        metadata: bool = False
     ):
         """Compute weighted average on selected series with the given weights.
 
@@ -1836,6 +1837,8 @@ class GroClient(object):
         latest_date_only: bool, optional
             False by default. If True, will return a single key-value pair where the key is the latested date.
             e.g. {'2000-03-12': 0.221}
+        metadata: bool, optional
+            False by default. If True, will return the metadata for the given series and weights.
 
         Returns
         -------
@@ -1852,6 +1855,7 @@ class GroClient(object):
             region_id,
             method,
             latest_date_only,
+            metadata
         )
 
     def get_area_weighting_weight_metadata(

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -275,6 +275,7 @@ def mock_get_area_weighted_series(
     region_id,
     method,
     latest_date_only,
+    metadata
 ):
     return {"2022-07-11": 0.715615, "2022-07-19": 0.733129, "2022-07-27": 0.748822}
 

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -844,6 +844,7 @@ def get_area_weighted_series(
     region_id: Union[int, List[int]],
     method: str,
     latest_date_only: bool,
+    metadata: bool,
 ):
     url = f"https://{api_host}/area-weighting"
     headers = {"authorization": "Bearer " + access_token}
@@ -855,6 +856,7 @@ def get_area_weighted_series(
         "regionIds": region_id,
         "method": method,
         "latestDateOnly": latest_date_only,
+        "metadata": metadata
     }
     resp = get_data(url, headers, params=params)
     return resp.json()

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -1108,19 +1108,42 @@ def test_get_area_weighting_weight_names(mock_requests_get):
 
 @mock.patch("requests.get")
 def test_get_area_weighted_series(mock_requests_get):
-    api_response = {
-        "2022-07-11": 0.715615,
-        "2022-07-19": 0.733129,
-        "2022-07-27": 0.748822,
+    api_response_with_metadata = {
+        "data_points": {
+            "2022-07-11": 0.715615,
+            "2022-07-19": 0.733129,
+            "2022-07-27": 0.748822
+        },
+        "series_description": {
+            "series_name": "dummy_series",
+            "item_id": 2,
+            "metric_id": 3,
+            "source_id": 4,
+            "frequency_id": 9,
+            "unit_id": 3,
+            "plain_words_name": "dummy",
+            "plain_words_source": "Gro"
+        },
+        "weight_description": [
+            {
+                "weight_name": "dummy weight",
+                "metric_id": 23,
+                "item_id": 41,
+                "source_id": 21,
+                "frequency_id": 12,
+                "unit_id": 31
+            }
+        ]
     }
-    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response)
+    api_response_without_metadata = api_response_with_metadata["data_points"]
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response_without_metadata)
 
-    expected_return = {
+    expected_return_without_metadata = {
         "2022-07-11": 0.715615,
         "2022-07-19": 0.733129,
         "2022-07-27": 0.748822,
     }
-    result = lib.get_area_weighted_series(
+    result_without_metadata = lib.get_area_weighted_series(
         MOCK_TOKEN,
         MOCK_HOST,
         "NDVI_8day",
@@ -1128,10 +1151,13 @@ def test_get_area_weighted_series(mock_requests_get):
         1215,
         "sum",
         False,
+        False
     )
-    assert result == expected_return
+    assert result_without_metadata == expected_return_without_metadata
 
-    result = lib.get_area_weighted_series(
+    initialize_requests_mocker_and_get_mock_data(mock_requests_get, api_response_with_metadata)
+
+    result_with_metadata = lib.get_area_weighted_series(
         MOCK_TOKEN,
         MOCK_HOST,
         "NDVI_8day",
@@ -1139,8 +1165,10 @@ def test_get_area_weighted_series(mock_requests_get):
         [1215],
         "sum",
         False,
+        True
     )
-    assert result == expected_return
+    expected_return_with_metadata = api_response_with_metadata
+    assert result_with_metadata == expected_return_with_metadata
 
 
 @mock.patch("requests.post")


### PR DESCRIPTION
**Goal**
The `/area-weighting` has the support for metadata parameter that allows to get metadata alongside the `weighted_data`. This PR adds metadata parameter to the area weighting function.
**Tested**
Tested manually its working with the dev api.
It seems stage and prod release hasn't happened yet.
`client.get_area_weighted_series("15851828_274_dtn_aggregated", ["Wheat", "Canola"], 1215, metadata=True)` returns metadata and data.