### PR TITLE
GAIA-26824 Remove the get_access_token from sdk and --print_token from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Navigate to [api/client/samples/](api/client/samples/) and try executing the pro
 4. You can also use the included `gro_client` tool as a quick way to request a single data series right on the command line. Try the following:
 
     ```sh
-    gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --user_email="email@example.com"
+    gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --token YOUR_GRO_API_TOKEN
     ```
 
     The `gro_client` command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked and the data points to the console. This tool is useful for simple queries, but anything more complex should be done using the provided Python packages.

--- a/docs/quick-start-projects/gro_client-tool.rst
+++ b/docs/quick-start-projects/gro_client-tool.rst
@@ -5,7 +5,7 @@ gro_client tool
 You can also use the included gro_client tool as a quick way to request a single data series right on the command line. Try the following:
 ::
 
-  gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --user_email="email@example.com"
+  gro_client --metric="Production Quantity mass" --item="Corn" --region="United States" --token YOUR_GRO_API_TOKEN
 
 
 The gro_client command line interface does a keyword search for the inputs and finds a random matching data series. It displays the data series it picked in the command line and writes the data points out to a file in the current directory called gro_client_output.csv. This tool is useful for simple queries, but anything more complex should be done using the Python packages.

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -69,8 +69,6 @@ def main():  # pragma: no cover
     For more information use --help
     """
     parser = argparse.ArgumentParser(description="Gro API command line interface")
-    parser.add_argument("--user_email")
-    parser.add_argument("--user_password")
     parser.add_argument("--item")
     parser.add_argument("--metric")
     parser.add_argument("--region")
@@ -88,9 +86,7 @@ def main():  # pragma: no cover
         print(groclient.lib.get_version_info().get("api-client-version"))
         return
 
-    assert (
-        args.user_email or args.token
-    ), "Need --token, or --user_email, or $GROAPI_TOKEN"
+    assert args.token, "Need --token, or the access token to be set in environment variable: $GROAPI_TOKEN"
 
     client = GroClient(groclient.cfg.API_HOST, args.token)
 

--- a/groclient/cli.py
+++ b/groclient/cli.py
@@ -66,7 +66,6 @@ def main():  # pragma: no cover
     Usage examples:
         gro_client --item=soybeans  --region=brazil --partner_region china --metric export
         gro_client --item=sesame --region=ethiopia
-        gro_client --user_email=john.doe@example.com  --print_token
     For more information use --help
     """
     parser = argparse.ArgumentParser(description="Gro API command line interface")
@@ -77,12 +76,6 @@ def main():  # pragma: no cover
     parser.add_argument("--region")
     parser.add_argument("--partner_region")
     parser.add_argument("--file")
-    parser.add_argument(
-        "--print_token",
-        action="store_true",
-        help="Output API access token for the given user email and password. "
-        "Save it in GROAPI_TOKEN environment variable.",
-    )
     parser.add_argument(
         "--token",
         default=os.environ.get("GROAPI_TOKEN"),
@@ -98,22 +91,8 @@ def main():  # pragma: no cover
     assert (
         args.user_email or args.token
     ), "Need --token, or --user_email, or $GROAPI_TOKEN"
-    access_token = None
 
-    if args.token:
-        access_token = args.token
-    else:
-        if not args.user_password:
-            args.user_password = getpass.getpass()
-        access_token = groclient.lib.get_access_token(
-            groclient.cfg.API_HOST, args.user_email, args.user_password
-        )
-
-    if args.print_token:
-        print(access_token)
-        return
-
-    client = GroClient(groclient.cfg.API_HOST, access_token)
+    client = GroClient(groclient.cfg.API_HOST, args.token)
 
     if (
         not args.metric

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -89,50 +89,6 @@ def get_default_logger():
     return logger
 
 
-def get_access_token(api_host, user_email, user_password, logger=None):
-    """Request an access token.
-    This is a DEPRECATED function and will no longer be supported after November 1, 2023!
-
-    Parameters
-    ----------
-    api_host : string
-        The API host's url, excluding 'https://'
-        ex. 'api.gro-intelligence.com'
-    user_email : string
-        Email address associated with user's Gro account
-    user_password : string
-        Password for user's Gro account
-    logger : logging.Logger
-        Alternative logger object if wanting to use a non-default one.
-        Otherwise get_default_logger() will be used.
-
-    Returns
-    -------
-    accessToken : string
-
-    """
-    warnings.warn(
-        f"get_access_token() is deprecated and will be removed on November 1, 2023.",
-        DeprecationWarning,
-        2,
-    )
-    retry_count = 0
-    if not logger:
-        logger = get_default_logger()
-    while retry_count <= cfg.MAX_RETRIES:
-        get_api_token = requests.post(
-            "https://" + api_host + "/api-token",
-            data={"email": user_email, "password": user_password},
-        )
-        if get_api_token.status_code == 200:
-            logger.debug("Authentication succeeded in get_access_token")
-            return get_api_token.json()["data"]["accessToken"]
-
-        logger.warning(f"Error in get_access_token: {get_api_token}")
-        retry_count += 1
-    raise Exception(f"Giving up on get_access_token after {retry_count} tries.")
-
-
 def redirect(old_params, migration):
     """Update query parameters to follow a redirection response from the API.
 


### PR DESCRIPTION
**Goal/Problem**:
With auth0, we no longer allow people to specify username and password to get their access token.
So `get_access_token` function, that allows people to use their username and password to fetch their access token needs to be removed.

We can see no calls to `/api-token` from non webapp origin with username and passwd for last 4 days. [Kibana](https://log-service-prod.internal.gro-intelligence.com/_plugin/kibana/goto/386e672e5484032fbd2301a6e343843c).

**Solution**.
Remove the `get_access_token` function from sdk and --print_token argument from cli.

**Testing**
Tested importing `get_access_token`: `from groclient.lib import get_access_token` throws an error as expected.
Tested gro_client:
```
python -m groclient --item=sesame --region=ethiopia works. (env variable is set)
python -m --item=sesame --region=ethiopia  --user_email prabesh throws error as expected
python -m --item=sesame --region=ethiopia  --print_token throws error as expected.
python -m --item=sesame --region=ethiopia  --token ... works.
python -m groclient --item=sesame --region=ethiopia without token gives error as expected. AssertionError: Need --token, or the access token to be set in environment variable: $GROAPI_TOKEN
```



