### PR TITLE
GAIA-29731 Add client function for v2 area weighting service

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -2019,7 +2019,7 @@ class GroClient(object):
             e.g. [{"item_id": 274, "metric_id": 2120001, "frequency_id": 15, "source_id": 88}, ...]
         weight_names: list of strs
             List of weight names that will be used to weight the provided series. Mutually exclusive with "weights".
-            e.g. ['Barley (ha)', 'Corn (ha)']
+            e.g. ['Barley', 'Corn']
             For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
         start_date: str, optional
             A timestamp of the format 'YYYY-MM-DD', e.g. '2023-01-01'

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1990,3 +1990,60 @@ class GroClient(object):
         ```
         """
         return lib.reverse_geocode_points(self.access_token, self.api_host, points)
+
+    def get_area_weighted_series_df(
+        self,
+        series_dict: Dict[str, int],
+        region_id: int,
+        weights: Optional[List[Dict[str, int]]],
+        weight_names: Optional[List[str]],
+        start_date: Optional[str],
+        end_date: Optional[str],
+        method: Optional[str],
+    ) -> pd.DataFrame:
+        """Compute weighted average on selected series with the given weights.
+
+        Returns a dataframe that contains weighted values and metadata.
+
+        Parameters
+        ----------
+        series_dict: dict
+            A dictionary that maps required entity types to its value.
+            e.g. {"item_id": 321, "metric_id": 70029, "frequency_id": 3, "source_id": 3}
+        region_id: integer
+            The region for which the weighted series will be computed
+            Supported region levels are (1, 2, 3, 4, 5, 8)
+        weights: list of dict
+            A list of dictionaries with each representing a weight object. Mutually exclusive with "weight_names".
+            e.g. [{"item_id": 274, "metric_id": 2120001, "frequency_id": 15, "source_id": 88}, ...]
+        weight_names: list of strs
+            List of weight names that will be used to weight the provided series. Mutually exclusive with "weights".
+            e.g. ['Barley (ha)', 'Corn (ha)']
+            For getting the full list of valid weight names, please call :meth:`~.get_area_weighting_weight_names`
+        start_date: str, optional
+            A timestamp of the format 'YYYY-MM-DD', e.g. '2023-01-01'
+        end_date: str, optional
+            A timestamp of the format 'YYYY-MM-DD', e.g. '2023-01-01'
+        method: str, optional, default="sum"
+            Multi-crop weights can be calculated with either 'sum' or 'normalize' method.
+
+        Returns
+        -------
+        DataFrame
+
+            Example::
+                start_date  value       end_date    available_date  region_id   item_id     metric_id   frequency_id    unit_id     source_id   weights
+            0   2016-04-26  0.502835    2016-04-26  2016-04-28      1215        321         70029       1               189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
+            1   2016-04-27  0.509729    2016-04-27  2016-04-29      1215        321         70029       1               189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
+        """
+        return lib.get_area_weighted_series_df(
+            self.access_token,
+            self.api_host,
+            series_dict,
+            region_id,
+            weights,
+            weight_names,
+            start_date,
+            end_date,
+            method,
+        )

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import os
 import time
+import pandas as pd
 
 from typing import Dict, List, Optional, Union
 
@@ -1993,13 +1994,13 @@ class GroClient(object):
 
     def get_area_weighted_series_df(
         self,
-        series_dict: Dict[str, int],
+        series: Dict[str, int],
         region_id: int,
-        weights: Optional[List[Dict[str, int]]],
-        weight_names: Optional[List[str]],
-        start_date: Optional[str],
-        end_date: Optional[str],
-        method: Optional[str],
+        weights: Optional[List[Dict[str, int]]] = None,
+        weight_names: Optional[List[str]] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        method: Optional[str] = "sum",
     ) -> pd.DataFrame:
         """Compute weighted average on selected series with the given weights.
 
@@ -2007,7 +2008,7 @@ class GroClient(object):
 
         Parameters
         ----------
-        series_dict: dict
+        series: dict
             A dictionary that maps required entity types to its value.
             e.g. {"item_id": 321, "metric_id": 70029, "frequency_id": 3, "source_id": 3}
         region_id: integer
@@ -2039,7 +2040,7 @@ class GroClient(object):
         return lib.get_area_weighted_series_df(
             self.access_token,
             self.api_host,
-            series_dict,
+            series,
             region_id,
             weights,
             weight_names,

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -974,6 +974,9 @@ def format_v2_area_weighting_response(response_content: Dict[str, Any]) -> pd.Da
         data_points = response_content["data_points"]
         weighted_series_df = pd.DataFrame(data_points)
 
+        if not len(weighted_series_df):
+            return weighted_series_df
+
         # convert unix timestamps and rename date cols
         datetime_col_mappings = {
             "start_date": "timestamp", # add start_date col which is equivalent to end_date

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -912,6 +912,112 @@ def reverse_geocode_points(access_token: str, api_host: str, points: list):
     return r.json()["data"]
 
 
+def validate_series_object(series_object):
+    required_entities = {"item_id", "metric_id", "frequency_id", "source_id"}
+
+    for entity in required_entities:
+        if entity not in series_object or not series_object[entity]:
+            raise ValueError(f"{entity} is required and supposed to be a positive integer.")
+
+    invalid_atts = set(series_object.keys()).difference(required_entities)
+    if len(invalid_atts):
+        raise ValueError(f"Unsupported fields: {invalid_atts}.")
+
+
+def generate_payload_for_v2_area_weighting(
+    series_dict: Dict[str, int],
+    region_id: int,
+    weights: Optional[List[Dict[str, int]]] = None,
+    weight_names: Optional[List[str]] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    method: Optional[str] = "sum",
+):
+    payload = {
+        "region_id": region_id,
+        "method": method,
+    }
+
+    # validate series and weights selection
+    try:
+        validate_series_object(series_dict)
+    except ValueError as error:
+        raise ValueError(f"Failed to parse series selection: {error}")
+    payload["series"] = series_dict
+
+    if weights and len(weights):
+        if weight_names:
+            raise ValueError(f"weights and weight_names are mutually exclusive. Please specify only one.")
+        try:
+            for weight_dict in weights:
+                validate_series_object(weight_dict)
+        except ValueError as error:
+            raise ValueError(f"Failed to parse weight selections: {error}")
+        payload["weights"] = weights
+    else:
+        if not weight_names or not len(weight_names):
+            raise ValueError(f"Please specify either weights or weight_names in params.")
+        payload["weight_names"] = weight_names
+
+    # add optional attrs
+    if start_date:
+        payload["start_date"] = start_date
+    if end_date:
+        payload["end_date"] = end_date
+
+    return json.dumps(payload)
+
+
+def format_v2_area_weighting_response(response_content: Dict[str, Any]) -> pd.DataFrame:
+    try:
+        data_points = response_content["data_points"]
+        weighted_series_df = pd.DataFrame(data_points)
+
+        # append selected fields of series metadata
+        for key in ['item_id', 'metric_id', 'frequency_id', 'unit_id', 'source_id']:
+            weighted_series_df[key] = response_content["series_description"][key]
+
+        # append weights metadata as a single json
+        weighted_series_df["weights_metadata"] = json.dumps(response_content["weights_description"])
+
+        return weighted_series_df
+    except KeyError as key:
+        raise Exception(f"Bad Implementation Error: missing {key} in API response.")
+
+
+def get_area_weighted_series_df(
+    access_token: str,
+    api_host: str,
+    series_dict: Dict[str, int],
+    region_id: int,
+    weights: Optional[List[Dict[str, int]]] = None,
+    weight_names: Optional[List[str]] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    method: Optional[str] = "sum",
+) -> pd.DataFrame:
+    payload = generate_payload_for_v2_area_weighting(
+        series_dict,
+        region_id,
+        weights,
+        weight_names,
+        start_date,
+        end_date,
+        method
+    )
+    response = requests.post(
+        f"https://{api_host}/v2/area-weighting",
+        data=payload,
+        headers={"Authorization": "Bearer " + access_token},
+    )
+
+    if response.status_code != 200:
+        raise Exception(response.text)
+
+    weighted_series_df = format_v2_area_weighting_response(response.json())
+    return weighted_series_df
+
+
 if __name__ == "__main__":
     # To run doctests:
     # $ python lib.py -v


### PR DESCRIPTION
**Goal:**
Add public function to python SDK, which calls POST `v2/area-weighting`.
The output format is mostly based on the sample provided in https://colab.research.google.com/drive/1XvJ-gMtnG8yeB3V6EnwzRuspt2ptdk2g#scrollTo=ZXqN95QzWA35

**Test:**
    series_dict = {
        "metric_id": 70029,
        "item_id": 321,
        "frequency_id": 3,
        "source_id": 3
    }
    selections = {
        "series": series_dict,
        "region_id": 1215,
        "weight_names": ["Wheat"],
        "start_date": "2023-10-01"
    }
    client.get_area_weighted_series_df(**selections)

<img width="907" alt="Screenshot 2024-01-04 at 9 25 35 PM" src="https://github.com/gro-intelligence/api-client/assets/59707294/ebc96e88-6cfd-4014-b26c-8dcaab1e3370">

