### PR TITLE
GAIA-30812 Update the python SDK to include new changes for v2/area-weighting

### DIFF
--- a/groclient/client.py
+++ b/groclient/client.py
@@ -2033,9 +2033,9 @@ class GroClient(object):
         DataFrame
 
             Example::
-                start_date  value       end_date    available_date  region_id   item_id     metric_id   frequency_id    unit_id     source_id   weights
-            0   2016-04-26  0.502835    2016-04-26  2016-04-28      1215        321         70029       1               189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
-            1   2016-04-27  0.509729    2016-04-27  2016-04-29      1215        321         70029       1               189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
+                start_date  value       end_date    available_date(optional)  region_id   item_id     metric_id   frequency_id    unit_id     source_id     weights
+            0   2016-04-26  0.502835    2016-04-26  2016-04-28                  1215        321         70029           1           189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
+            1   2016-04-27  0.509729    2016-04-27  2016-04-29                  1215        321         70029           1           189         112         [{"weight_name": "Corn", "item_id": 274, "metric_id": 2120001, ...}, ...]
         """
         return lib.get_area_weighted_series_df(
             self.access_token,

--- a/groclient/client.py
+++ b/groclient/client.py
@@ -1995,7 +1995,7 @@ class GroClient(object):
     def get_area_weighted_series_df(
         self,
         series: Dict[str, int],
-        region_id: int,
+        region_ids: List[int],
         weights: Optional[List[Dict[str, int]]] = None,
         weight_names: Optional[List[str]] = None,
         start_date: Optional[str] = None,
@@ -2011,8 +2011,8 @@ class GroClient(object):
         series: dict
             A dictionary that maps required entity types to its value.
             e.g. {"item_id": 321, "metric_id": 70029, "frequency_id": 3, "source_id": 3}
-        region_id: integer
-            The region for which the weighted series will be computed
+        region_ids: list of integer
+            The selected regions for which the weighted series will be computed
             Supported region levels are (1, 2, 3, 4, 5, 8)
         weights: list of dict
             A list of dictionaries with each representing a weight object. Mutually exclusive with "weight_names".
@@ -2041,7 +2041,7 @@ class GroClient(object):
             self.access_token,
             self.api_host,
             series,
-            region_id,
+            region_ids,
             weights,
             weight_names,
             start_date,

--- a/groclient/client_test.py
+++ b/groclient/client_test.py
@@ -725,7 +725,7 @@ class GroClientTests(TestCase):
                 "frequency_id": 3,
                 "source_id": 3
             },
-            "region_id": 1215,
+            "region_ids": [1215],
             "weight_names": ["Wheat"],
             "start_date": "2023-10-01"
         }

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -926,6 +926,12 @@ def generate_payload_for_v2_area_weighting(
 
 
 def format_v2_area_weighting_response(response_content: Dict[str, Any]) -> pd.DataFrame:
+    DATETIME_COL_MAPPINGS = {
+        "start_date": "timestamp", # add start_date col which is equivalent to end_date
+        "end_date": "timestamp",
+        "available_date": "available_timestamp",
+    }
+
     try:
         data_points = response_content["data_points"]
         weighted_series_df = pd.DataFrame(data_points)
@@ -934,14 +940,10 @@ def format_v2_area_weighting_response(response_content: Dict[str, Any]) -> pd.Da
             return weighted_series_df
 
         # convert unix timestamps and rename date cols
-        datetime_col_mappings = {
-            "start_date": "timestamp", # add start_date col which is equivalent to end_date
-            "end_date": "timestamp",
-            "available_date": "available_timestamp",
-        }
-        for new_col, col in datetime_col_mappings.items():
-            weighted_series_df[new_col] = pd.to_datetime(weighted_series_df[col], unit='s').dt.strftime('%Y-%m-%d')
-        weighted_series_df = weighted_series_df.drop(columns=datetime_col_mappings.values())
+        for new_col, col in DATETIME_COL_MAPPINGS.items():
+            if col in weighted_series_df.columns:
+                weighted_series_df[new_col] = pd.to_datetime(weighted_series_df[col], unit='s').dt.strftime('%Y-%m-%d')
+        weighted_series_df = weighted_series_df.drop(columns=DATETIME_COL_MAPPINGS.values(), errors="ignore")
 
         # append selected fields of series metadata
         for key in ['item_id', 'metric_id', 'frequency_id', 'unit_id', 'source_id']:

--- a/groclient/lib.py
+++ b/groclient/lib.py
@@ -883,7 +883,7 @@ def validate_series_object(series_object):
 
 def generate_payload_for_v2_area_weighting(
     series: Dict[str, int],
-    region_id: int,
+    region_ids: List[int],
     weights: Optional[List[Dict[str, int]]] = None,
     weight_names: Optional[List[str]] = None,
     start_date: Optional[str] = None,
@@ -891,7 +891,7 @@ def generate_payload_for_v2_area_weighting(
     method: Optional[str] = "sum",
 ):
     payload = {
-        "region_id": region_id,
+        "region_ids": region_ids,
         "method": method,
     }
 
@@ -959,7 +959,7 @@ def get_area_weighted_series_df(
     access_token: str,
     api_host: str,
     series: Dict[str, int],
-    region_id: int,
+    region_ids: List[int],
     weights: Optional[List[Dict[str, int]]] = None,
     weight_names: Optional[List[str]] = None,
     start_date: Optional[str] = None,
@@ -968,7 +968,7 @@ def get_area_weighted_series_df(
 ) -> pd.DataFrame:
     payload = generate_payload_for_v2_area_weighting(
         series,
-        region_id,
+        region_ids,
         weights,
         weight_names,
         start_date,

--- a/groclient/lib_test.py
+++ b/groclient/lib_test.py
@@ -1228,7 +1228,7 @@ def test_get_area_weighted_series_df(mock_requests_post):
             "frequency_id": 3,
             "source_id": 3
         },
-        "region_id": 1215,
+        "region_ids": [1215],
         "weight_names": ["Corn", "Wheat"],
         "start_date": "2023-10-01"
     }


### PR DESCRIPTION
follow up ticket of https://github.com/gro-intelligence/gro/pull/14096

the python service v2/area-weighting supports legacy version of get_area_weighted_series_df as well.